### PR TITLE
refactor: remove unused state variable hasName

### DIFF
--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -40,7 +40,6 @@ const Terminalcomp = () => {
     }
   });
   const terminalRef = useRef(null);
-  const [hasName, setHasName] = useState(null);
   const [userName, setUserName] = useState('');
   const [isAskingName, setIsAskingName] = useState(false);
   const [visitedBefore, setVisitedBefore] = useState(false);
@@ -494,7 +493,7 @@ const Terminalcomp = () => {
             </div>
           ))}
 
-          {isAskingName && !hasName && (
+          {isAskingName && (
             <div className="mb-2 sm:mb-4 text-xs sm:text-sm text-yellow-400">
               Please enter your name to continue:
             </div>


### PR DESCRIPTION
Removed the unused state variable 'hasName' from app/components/Terminal/Terminal.tsx to improve code health.
Verified that the functionality remains correct and the terminal still prompts for the user name when necessary.

---
*PR created automatically by Jules for task [147744630656799837](https://jules.google.com/task/147744630656799837) started by @Pranav322*