### PR TITLE
🔒 Fix unsafe eval usage in Terminal

### DIFF
--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { TerminalSquare } from 'lucide-react';
+import { safeEvaluate } from '@/lib/math';
 
 const Terminalcomp = () => {
   const [input, setInput] = useState('');
@@ -411,14 +412,14 @@ const Terminalcomp = () => {
 
       default:
         // Handle math expressions
-        if (/^\d+[+\-*/]\d+$/.test(fullCommand)) {
-          try {
-            output = eval(fullCommand);
-          } catch (error) {
+        try {
+          output = safeEvaluate(fullCommand);
+        } catch (error) {
+          if (error instanceof Error && error.message === 'Invalid expression format') {
+            output = `bash: ${command}: command not found`;
+          } else {
             output = 'bash: syntax error in expression';
           }
-        } else {
-          output = `bash: ${command}: command not found`;
         }
         break;
     }

--- a/lib/math.ts
+++ b/lib/math.ts
@@ -1,0 +1,38 @@
+export function safeEvaluate(expression: string): number | string {
+  // Regex to ensure safe input (integer arithmetic only)
+  // This matches: 1+2, 10-5, 100*2, 50/2
+  const regex = /^\d+[+\-*/]\d+$/;
+  if (!regex.test(expression)) {
+    throw new Error('Invalid expression format');
+  }
+
+  // Parse operator
+  const operatorMatch = expression.match(/[+\-*/]/);
+  if (!operatorMatch) {
+    throw new Error('Invalid operator');
+  }
+
+  const operator = operatorMatch[0];
+  const [leftStr, rightStr] = expression.split(operator);
+
+  const left = parseInt(leftStr, 10);
+  const right = parseInt(rightStr, 10);
+
+  if (isNaN(left) || isNaN(right)) {
+    throw new Error('Invalid numbers');
+  }
+
+  switch (operator) {
+    case '+':
+      return left + right;
+    case '-':
+      return left - right;
+    case '*':
+      return left * right;
+    case '/':
+      if (right === 0) return Infinity;
+      return left / right;
+    default:
+      throw new Error('Unknown operator');
+  }
+}


### PR DESCRIPTION
🎯 **What:** Replaced the unsafe usage of `eval()` in `app/components/Terminal/Terminal.tsx`.
⚠️ **Risk:** Although guarded by a regex, using `eval()` is a security risk as it can execute arbitrary JavaScript code if the validation is bypassed or flawed.
🛡️ **Solution:** Implemented a `safeEvaluate` utility function in `lib/math.ts` that strictly parses and computes simple arithmetic expressions (`+`, `-`, `*`, `/`) between integers, ensuring no arbitrary code execution is possible.

---
*PR created automatically by Jules for task [15326174169058429580](https://jules.google.com/task/15326174169058429580) started by @Pranav322*