### PR TITLE
chore: remove unused IconDeviceGamepad2 import in floating-dock.tsx

### DIFF
--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -5,7 +5,7 @@
  **/
 
 import { cn } from '@/lib/utils';
-import { IconLayoutNavbarCollapse, IconDeviceGamepad2 } from '@tabler/icons-react';
+import { IconLayoutNavbarCollapse } from '@tabler/icons-react';
 import {
   AnimatePresence,
   MotionValue,


### PR DESCRIPTION
Removed unused import `IconDeviceGamepad2` from `app/components/ui/floating-dock.tsx` to improve code health.
Verified that the import was unused by reading the file and checking for usages.
Ran `npm run lint` and `npm run build` to ensure no regressions.

---
*PR created automatically by Jules for task [15696961304877838516](https://jules.google.com/task/15696961304877838516) started by @Pranav322*