### PR TITLE
🎨 Palette: Add keyboard focus tooltips to Floating Dock

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 
 **Learning:** `framer-motion` components often obscure underlying semantic elements. Using conditional rendering to swap `motion.div` wrappers with semantic `Link` or `button` elements (while preserving layout/animation props) is crucial for keyboard accessibility.
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
+
+## 2025-02-23 - Tooltips for Keyboard Focus
+**Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
+**Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -201,6 +201,7 @@ function IconContainer({
   });
 
   const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
 
   const isExternal = href && href.startsWith('http');
   const isLink = isExternal || (href && href !== '#');
@@ -214,7 +215,7 @@ function IconContainer({
       className="aspect-square rounded-full bg-gray-200 dark:bg-neutral-800 flex items-center justify-center relative"
     >
       <AnimatePresence>
-        {hovered && (
+        {(hovered || focused) && (
           <motion.div
             initial={{ opacity: 0, y: 10, x: '-50%' }}
             animate={{ opacity: 1, y: 0, x: '-50%' }}
@@ -245,6 +246,8 @@ function IconContainer({
         target={isExternal ? '_blank' : undefined}
         rel={isExternal ? 'noopener noreferrer' : undefined}
         aria-label={title}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
       >
         {content}
       </Link>
@@ -257,6 +260,8 @@ function IconContainer({
       className={cn('bg-transparent border-none p-0 cursor-pointer', containerClass)}
       type="button"
       aria-label={title}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
     >
       {content}
     </button>


### PR DESCRIPTION
Improved the accessibility of the FloatingDock component by ensuring tooltips are visible when icon-only buttons receive keyboard focus. Previously, tooltips only appeared on hover, making it difficult for keyboard users to identify dock items.

Changes:
- Modified `app/components/ui/floating-dock.tsx` to track focus state.
- Updated tooltip conditional rendering to include the focused state.
- Added a journal entry to `.Jules/palette.md` documenting this accessibility pattern.

Verified by running a Playwright script that focused a dock item and captured a screenshot showing the tooltip visible. passed `pnpm lint` and `pnpm build`.

---
*PR created automatically by Jules for task [12995211815925658287](https://jules.google.com/task/12995211815925658287) started by @Pranav322*