### PR TITLE
Remove unused showMusic state and JSX from DesktopIcons

### DIFF
--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -95,7 +95,6 @@ export function DesktopIcons({
   const [showBrowser, setShowBrowser] = useState(false);
   const [showSkills, setShowSkills] = useState(false);
   const [showPdf, setShowPdf] = useState(false);
-  const [showMusic, setShowMusic] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showSpotify, setShowSpotify] = useState(false);
   const [showExperience, setShowExperience] = useState(false);
@@ -499,12 +498,6 @@ export function DesktopIcons({
         <BrowserWindow
           initialUrl="https://iframee.vercel.app"
           onClose={() => setShowBrowser(false)}
-        />
-      )}
-      {showMusic && (
-        <BrowserWindow
-          initialUrl="https://soulifyy.vercel.app"
-          onClose={() => setShowMusic(false)}
         />
       )}
       {showSpotify && <SpotifyWindow onClose={() => setShowSpotify(false)} />}


### PR DESCRIPTION
Removed unused `showMusic` state and associated JSX in `app/components/ui/DesktopIcons.tsx`.
Verified that `setShowMusic` was never called with `true`, making the code dead.
Verified build and lint checks pass.
No user-visible changes are expected as the code was unreachable.


---
*PR created automatically by Jules for task [12824723796137105810](https://jules.google.com/task/12824723796137105810) started by @Pranav322*