### PR TITLE
⚡ Bolt: Debounce resize listener in DesktopIcons

### DIFF
--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -7,6 +7,8 @@ const useDeviceType = () => {
   const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+
     const checkDeviceType = () => {
       const width = window.innerWidth;
       const height = window.innerHeight;
@@ -22,9 +24,18 @@ const useDeviceType = () => {
       }
     };
 
+    const handleResize = () => {
+      clearTimeout(timeoutId);
+      // Debounce resize to prevent excessive state updates
+      timeoutId = setTimeout(checkDeviceType, 100);
+    };
+
     checkDeviceType();
-    window.addEventListener('resize', checkDeviceType);
-    return () => window.removeEventListener('resize', checkDeviceType);
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      clearTimeout(timeoutId);
+    };
   }, []);
 
   return { deviceType, windowSize };


### PR DESCRIPTION
💡 What: Debounced the window resize event listener in `app/components/ui/DesktopIcons.tsx` using a 100ms delay.
🎯 Why: Resizing the browser window triggered state updates (`setWindowSize` and `setDeviceType`) on every frame, causing excessive re-renders of the `DesktopIcons` component and its children.
📊 Impact: Reduces re-renders significantly during window resizing, improving UI responsiveness.
🔬 Measurement: Verify by resizing the window and observing smoother performance; `npm run build` confirms no build errors.

---
*PR created automatically by Jules for task [1512885656623593521](https://jules.google.com/task/1512885656623593521) started by @Pranav322*