### PR TITLE
🎨 Palette: Accessible Desktop Icons & Tooltip Fix

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-05-15 - Tooltip Positioning in Mapped Lists
+**Learning:** Using a single `useRef` for positioning tooltips in a mapped list causes the tooltip to always anchor to the last rendered item.
+**Action:** For list items, avoid `ref` based positioning. Instead, capture `event.currentTarget.getBoundingClientRect()` in the click/hover handler and store the coordinates in state to position the tooltip dynamically.

--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -127,10 +127,16 @@ export function DesktopIcons({
   const [showExperience, setShowExperience] = useState(false);
   const [showPranavChat, setShowPranavChat] = useState(false);
   const [clickHelpIcon, setClickHelpIcon] = useState<string | null>(null);
-  const clickHelpRef = useRef<HTMLDivElement>(null);
+  const [tooltipPosition, setTooltipPosition] = useState<{ top: number; left: number } | null>(null);
   const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const handleIconClick = (iconName: string, action?: () => void) => {
+  const handleIconClick = (e: React.MouseEvent, iconName: string, action?: () => void) => {
+    // Capture position for tooltip if desktop
+    if (deviceType === 'desktop') {
+      const rect = e.currentTarget.getBoundingClientRect();
+      setTooltipPosition({ top: rect.top, left: rect.left });
+    }
+
     // On mobile/tablet, single tap opens the window
     if (deviceType === 'mobile' || deviceType === 'tablet') {
       if (action) {
@@ -373,11 +379,11 @@ export function DesktopIcons({
             {organizedColumns.map((column, columnIndex) => (
               <div key={columnIndex} className="flex flex-col gap-3">
                 {column.map(icon => (
-                  <div
+                  <button
+                    type="button"
                     key={icon.name}
-                    className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
-                    onClick={() => handleIconClick(icon.name, icon.action)}
-                    ref={clickHelpRef}
+                    className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback bg-transparent border-none ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
+                    onClick={(e) => handleIconClick(e, icon.name, icon.action)}
                   >
                     <div
                       className={`p-2 sm:p-3 rounded-lg backdrop-blur-md transition-all`}
@@ -402,7 +408,7 @@ export function DesktopIcons({
                     >
                       {icon.name}
                     </span>
-                  </div>
+                  </button>
                 ))}
               </div>
             ))}
@@ -410,11 +416,11 @@ export function DesktopIcons({
         ) : (
           <div className={getLayoutClasses()}>
             {icons.map(icon => (
-              <div
+              <button
+                type="button"
                 key={icon.name}
-                className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
-                onClick={() => handleIconClick(icon.name, icon.action)}
-                ref={clickHelpRef}
+                className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback bg-transparent border-none ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
+                onClick={(e) => handleIconClick(e, icon.name, icon.action)}
               >
                 <div
                   className={`p-2 sm:p-3 rounded-lg backdrop-blur-md transition-all`}
@@ -439,7 +445,7 @@ export function DesktopIcons({
                 >
                   {icon.name}
                 </span>
-              </div>
+              </button>
             ))}
           </div>
         )}
@@ -453,8 +459,8 @@ export function DesktopIcons({
             exit={{ opacity: 0, y: -20 }}
             className="fixed flex items-center gap-2 px-4 py-2 bg-white/20 backdrop-blur-lg text-white/90 text-base rounded-lg border border-white/20 shadow-lg"
             style={{
-              left: `clamp(1rem, ${(clickHelpRef.current?.getBoundingClientRect().left || 0) + 120}px, calc(100vw - 300px))`,
-              top: Math.max(20, (clickHelpRef.current?.getBoundingClientRect().top || 0) - 50),
+              left: `clamp(1rem, ${(tooltipPosition?.left || 0) + 120}px, calc(100vw - 300px))`,
+              top: Math.max(20, (tooltipPosition?.top || 0) - 50),
             }}
           >
             <IconInfoCircle className="animate-pulse" size={20} />

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,17 @@
+
+> portfolio@0.1.0 dev /app
+> next dev --turbopack
+
+   ▲ Next.js 15.5.12 (Turbopack)
+   - Local:        http://localhost:3000
+   - Network:      http://192.168.0.2:3000
+
+ ✓ Starting...
+ ✓ Ready in 1490ms
+ ⚠ Webpack is configured while Turbopack is not, which may cause problems.
+ ⚠ See instructions if you need to configure Turbopack:
+  https://nextjs.org/docs/app/api-reference/next-config-js/turbopack
+
+ ○ Compiling / ...
+ ✓ Compiled / in 9.7s
+ GET / 200 in 10963ms


### PR DESCRIPTION
💡 What:
- Refactored `DesktopIcons` to use semantic `<button>` elements instead of `<div>`.
- Fixed a bug where the "Double-click to open" tooltip was mispositioned due to incorrect `ref` usage in a loop.

🎯 Why:
- Improves accessibility for keyboard users and screen readers (buttons are focusable and announceable).
- Fixes a visual bug where the tooltip appeared near the wrong icon.

♿ Accessibility:
- Replaced `div` with `<button type="button">`.
- Added keyboard support implicitly via button (Enter/Space works).
- Tooltip is now correctly associated with the focused/clicked element visually.

---
*PR created automatically by Jules for task [3200528853304351767](https://jules.google.com/task/3200528853304351767) started by @Pranav322*