### PR TITLE
Make desktop icons keyboard accessible

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -168,12 +168,12 @@ export function DesktopIcons({
   const [showExperience, setShowExperience] = useState(false);
   const [showPranavChat, setShowPranavChat] = useState(false);
   const [clickHelpIcon, setClickHelpIcon] = useState<string | null>(null);
-  const clickHelpRef = useRef<HTMLDivElement>(null);
+  const clickHelpRef = useRef<HTMLButtonElement>(null);
   const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const handleIconClick = (iconName: string, action?: () => void) => {
+  const handleIconClick = (iconName: string, action?: () => void, isKeyboard: boolean = false) => {
     // On mobile/tablet, single tap opens the window
-    if (deviceType === 'mobile' || deviceType === 'tablet') {
+    if (deviceType === 'mobile' || deviceType === 'tablet' || isKeyboard) {
       if (action) {
         action();
       } else {
@@ -414,14 +414,16 @@ export function DesktopIcons({
             {organizedColumns.map((column, columnIndex) => (
               <div key={columnIndex} className="flex flex-col gap-3">
                 {column.map(icon => (
-                  <motion.div
+                  <motion.button
+                    type="button"
                     key={icon.name}
-                    className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
-                    onClick={() => handleIconClick(icon.name, icon.action)}
+                    className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback bg-transparent border-none ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
+                    onClick={e => handleIconClick(icon.name, icon.action, e.detail === 0)}
                     onMouseEnter={() => handlePrefetch(icon.name)}
                     whileTap={{ scale: 0.92 }}
                     transition={{ type: 'spring', stiffness: 400, damping: 17 }}
                     ref={clickHelpRef}
+                    aria-label={icon.name}
                   >
                     <div
                       className={`p-2 sm:p-3 rounded-lg backdrop-blur-md transition-all`}
@@ -446,7 +448,7 @@ export function DesktopIcons({
                     >
                       {icon.name}
                     </span>
-                  </motion.div>
+                  </motion.button>
                 ))}
               </div>
             ))}
@@ -454,14 +456,16 @@ export function DesktopIcons({
         ) : (
           <div className={getLayoutClasses()}>
             {icons.map(icon => (
-              <motion.div
+              <motion.button
+                type="button"
                 key={icon.name}
-                className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
-                onClick={() => handleIconClick(icon.name, icon.action)}
+                className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback bg-transparent border-none ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
+                onClick={e => handleIconClick(icon.name, icon.action, e.detail === 0)}
                 onMouseEnter={() => handlePrefetch(icon.name)}
                 whileTap={{ scale: 0.92 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 17 }}
                 ref={clickHelpRef}
+                aria-label={icon.name}
               >
                 <div
                   className={`p-2 sm:p-3 rounded-lg backdrop-blur-md transition-all`}
@@ -486,7 +490,7 @@ export function DesktopIcons({
                 >
                   {icon.name}
                 </span>
-              </motion.div>
+              </motion.button>
             ))}
           </div>
         )}


### PR DESCRIPTION
Improved accessibility of desktop icons by using semantic `<button>` elements. Added keyboard support where pressing Enter opens the app immediately, bypassing the double-click requirement used for mouse interactions. This ensures keyboard users can launch applications from the desktop.

---
*PR created automatically by Jules for task [13419743571626543576](https://jules.google.com/task/13419743571626543576) started by @Pranav322*