### PR TITLE
⚡ Bolt: Optimize DesktopIcons tooltip rendering

### DIFF
--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -168,10 +168,10 @@ export function DesktopIcons({
   const [showExperience, setShowExperience] = useState(false);
   const [showPranavChat, setShowPranavChat] = useState(false);
   const [clickHelpIcon, setClickHelpIcon] = useState<string | null>(null);
-  const clickHelpRef = useRef<HTMLDivElement>(null);
+  const [tooltipPosition, setTooltipPosition] = useState<{ x: number; y: number } | null>(null);
   const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const handleIconClick = (iconName: string, action?: () => void) => {
+  const handleIconClick = (e: React.MouseEvent, iconName: string, action?: () => void) => {
     // On mobile/tablet, single tap opens the window
     if (deviceType === 'mobile' || deviceType === 'tablet') {
       if (action) {
@@ -229,6 +229,8 @@ export function DesktopIcons({
       }
     } else {
       // First click
+      const rect = e.currentTarget.getBoundingClientRect();
+      setTooltipPosition({ x: rect.left, y: rect.top });
       setSelectedIcon(iconName);
       setClickHelpIcon(iconName);
       if (clickTimeoutRef.current) {
@@ -417,11 +419,10 @@ export function DesktopIcons({
                   <motion.div
                     key={icon.name}
                     className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
-                    onClick={() => handleIconClick(icon.name, icon.action)}
+                    onClick={e => handleIconClick(e, icon.name, icon.action)}
                     onMouseEnter={() => handlePrefetch(icon.name)}
                     whileTap={{ scale: 0.92 }}
                     transition={{ type: 'spring', stiffness: 400, damping: 17 }}
-                    ref={clickHelpRef}
                   >
                     <div
                       className={`p-2 sm:p-3 rounded-lg backdrop-blur-md transition-all`}
@@ -457,11 +458,10 @@ export function DesktopIcons({
               <motion.div
                 key={icon.name}
                 className={`group flex flex-col items-center gap-1 cursor-pointer touch-target tap-feedback ${getIconContainerClasses()} ${selectedIcon === icon.name ? 'bg-white/20 rounded-lg p-2' : 'p-2'}`}
-                onClick={() => handleIconClick(icon.name, icon.action)}
+                onClick={e => handleIconClick(e, icon.name, icon.action)}
                 onMouseEnter={() => handlePrefetch(icon.name)}
                 whileTap={{ scale: 0.92 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 17 }}
-                ref={clickHelpRef}
               >
                 <div
                   className={`p-2 sm:p-3 rounded-lg backdrop-blur-md transition-all`}
@@ -493,15 +493,15 @@ export function DesktopIcons({
       </div>
 
       <AnimatePresence>
-        {clickHelpIcon && deviceType === 'desktop' && (
+        {clickHelpIcon && deviceType === 'desktop' && tooltipPosition && (
           <motion.div
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -20 }}
             className="fixed flex items-center gap-2 px-4 py-2 bg-white/20 backdrop-blur-lg text-white/90 text-base rounded-lg border border-white/20 shadow-lg"
             style={{
-              left: `clamp(1rem, ${(clickHelpRef.current?.getBoundingClientRect().left || 0) + 120}px, calc(100vw - 300px))`,
-              top: Math.max(20, (clickHelpRef.current?.getBoundingClientRect().top || 0) - 50),
+              left: `clamp(1rem, ${tooltipPosition.x + 120}px, calc(100vw - 300px))`,
+              top: Math.max(20, tooltipPosition.y - 50),
             }}
           >
             <IconInfoCircle className="animate-pulse" size={20} />

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,21 @@
+
+> portfolio@0.1.0 dev /app
+> next dev --turbopack
+
+   ▲ Next.js 15.5.12 (Turbopack)
+   - Local:        http://localhost:3000
+   - Network:      http://192.168.0.2:3000
+
+ ✓ Starting...
+ ✓ Ready in 1774ms
+ ⚠ Webpack is configured while Turbopack is not, which may cause problems.
+ ⚠ See instructions if you need to configure Turbopack:
+  https://nextjs.org/docs/app/api-reference/next-config-js/turbopack
+
+ ○ Compiling /_not-found/page ...
+ ✓ Compiled /_not-found/page in 5.3s
+ GET /robots.txt 404 in 6102ms
+ ○ Compiling / ...
+ ✓ Compiled / in 5.6s
+ GET / 200 in 6357ms
+ GET / 200 in 333ms


### PR DESCRIPTION
💡 What: Refactored `DesktopIcons` to calculate tooltip position in `onClick` handler instead of during render.
🎯 Why:
1. Performance: Removes `getBoundingClientRect()` call from the render phase, eliminating forced synchronous reflows (layout thrashing).
2. Correctness: Fixes a bug where `clickHelpRef` was used in a loop, causing the tooltip to always appear near the last icon instead of the clicked one.
📊 Impact: Eliminates layout thrashing during tooltip display. Corrects tooltip positioning for all icons.
🔬 Measurement: Verified with Playwright script that tooltip now appears correctly next to the clicked icon (e.g., "About Me" vs "Projects") instead of a fixed location.

---
*PR created automatically by Jules for task [12907801151392648215](https://jules.google.com/task/12907801151392648215) started by @Pranav322*