### PR TITLE
🎨 Palette: Desktop Icons Accessibility & Bug Fix

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,11 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Dynamic Positioning for Mapped Elements
+**Learning:** Using a single `useRef` for elements in a map loop will only capture the last element, causing positioning bugs for overlays (like tooltips).
+**Action:** Use `useState<HTMLElement | null>` to store `event.currentTarget` as the anchor element for precise positioning relative to the interacted item.
+
+## 2025-02-23 - Keyboard Detection in Click Handlers
+**Learning:** React's `onClick` event fires for both mouse clicks and keyboard activation (Enter/Space) on buttons. `event.detail === 0` reliably identifies keyboard activation.
+**Action:** Use `event.detail === 0` to provide keyboard-specific behavior (like single-press activation) while maintaining mouse-specific logic (like double-click).

--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,18 @@
+
+> portfolio@0.1.0 dev /app
+> next dev --turbopack
+
+   ▲ Next.js 15.5.12 (Turbopack)
+   - Local:        http://localhost:3000
+   - Network:      http://192.168.0.2:3000
+
+ ✓ Starting...
+ ✓ Ready in 1561ms
+ ⚠ Webpack is configured while Turbopack is not, which may cause problems.
+ ⚠ See instructions if you need to configure Turbopack:
+  https://nextjs.org/docs/app/api-reference/next-config-js/turbopack
+
+ ○ Compiling / ...
+ ✓ Compiled / in 9.6s
+ GET / 200 in 11033ms
+ GET / 200 in 767ms


### PR DESCRIPTION
💡 What: Refactored desktop icons from `motion.div` to semantic `motion.button` elements. Improved keyboard accessibility by allowing single Enter/Space press to open apps. Fixed a bug where the "Double-click to open" tooltip was anchored to the wrong icon.
🎯 Why: Desktop icons were inaccessible to keyboard users and relied on mouse double-click logic. The tooltip positioning was broken due to incorrect ref usage.
📸 Before/After: Added focus rings and corrected tooltip positioning (verified via screenshot).
♿ Accessibility: Added proper button semantics, aria-labels, and keyboard activation support.

---
*PR created automatically by Jules for task [4905064513711286249](https://jules.google.com/task/4905064513711286249) started by @Pranav322*