### PR TITLE
🎨 Palette: Enhance Terminal Accessibility

### DIFF
--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -475,12 +475,19 @@ const Terminalcomp = () => {
       <div className="border-2 border-neutral-800 dark:border-neutral-700 rounded-sm w-full max-w-[700px] h-[500px] max-h-[80vh] bg-black/90 backdrop-blur-sm p-2 sm:p-4 overflow-y-auto font-mono terminal-glow mobile-hide-scrollbar custom-scrollbar">
         <div className="flex justify-between mb-3 sm:mb-5 items-center sticky top-0 bg-black/90 z-20 backdrop-blur-lg p-1 sm:p-2 rounded-sm">
           <div className="flex gap-1 sm:gap-2">
-            <div
-              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-red-500 rounded-full hover:bg-red-400"
+            <button
+              aria-label="Close terminal"
+              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-red-500 rounded-full hover:bg-red-400 border-none p-0 appearance-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-red-400"
               onClick={() => (window.location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')}
+            ></button>
+            <div
+              aria-hidden="true"
+              className="w-2 h-2 sm:w-3 sm:h-3 bg-yellow-500 rounded-full cursor-default opacity-80"
             ></div>
-            <div className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-yellow-500 rounded-full hover:bg-yellow-400"></div>
-            <div className="w-2 h-2 sm:w-3 sm:h-3 cursor-pointer duration-200 bg-green-500 rounded-full hover:bg-green-400"></div>
+            <div
+              aria-hidden="true"
+              className="w-2 h-2 sm:w-3 sm:h-3 bg-green-500 rounded-full cursor-default opacity-80"
+            ></div>
           </div>
           <h1 className="text-white text-xs sm:text-sm truncate mx-2">{getPrompt()}</h1>
           <span className="flex gap-1 text-xs sm:text-sm border border-white/20 rounded-sm px-1 sm:px-2 py-0.5 sm:py-1 text-green-400">
@@ -488,7 +495,7 @@ const Terminalcomp = () => {
             <span className="hidden sm:inline">bash</span>
           </span>
         </div>
-        <div className="p-1 sm:p-2 text-green-100">
+        <div className="p-1 sm:p-2 text-green-100" aria-live="polite">
           <TerminalClock />
 
           {commands.map(command => (
@@ -530,6 +537,7 @@ const Terminalcomp = () => {
                 className="bg-transparent w-full outline-none border-none focus:outline-none text-white caret-green-500 text-xs sm:text-sm"
                 spellCheck={false}
                 autoFocus
+                aria-label="Terminal command input"
               />
             </form>
           </div>

--- a/pnpm_dev.log
+++ b/pnpm_dev.log
@@ -1,0 +1,20 @@
+
+> portfolio@0.1.0 dev /app
+> next dev --turbopack
+
+   ▲ Next.js 15.5.12 (Turbopack)
+   - Local:        http://localhost:3000
+   - Network:      http://192.168.0.2:3000
+
+ ✓ Starting...
+ ✓ Ready in 1546ms
+ ⚠ Webpack is configured while Turbopack is not, which may cause problems.
+ ⚠ See instructions if you need to configure Turbopack:
+  https://nextjs.org/docs/app/api-reference/next-config-js/turbopack
+
+ ○ Compiling / ...
+ ✓ Compiled / in 8.1s
+ HEAD / 200 in 9483ms
+ GET / 200 in 455ms
+ ELIFECYCLE  Command failed.
+[?25h


### PR DESCRIPTION
This PR improves the accessibility of the Terminal component by converting the "Close" control to a semantic button with an accessible label, marking non-functional controls as decorative, and ensuring screen readers announce new terminal output via `aria-live`. This enhances the experience for keyboard and screen reader users.

---
*PR created automatically by Jules for task [15994509138103083473](https://jules.google.com/task/15994509138103083473) started by @Pranav322*