### PR TITLE
⚡ Bolt: Memoize desktop components to reduce re-renders

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, memo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -95,4 +95,5 @@ function FloatingDockDemo({
   );
 }
 
-export default FloatingDockDemo;
+// Memoized to prevent re-renders when parent state changes
+export default memo(FloatingDockDemo);

--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useMemo, memo } from 'react';
 import { AnimatePresence } from 'framer-motion';
 
 // Hook to detect device types
@@ -149,7 +149,8 @@ const handlePrefetch = (iconName: string) => {
 };
 import { useTheme } from '../../contexts/ThemeContext';
 
-export function DesktopIcons({
+// Memoized to prevent re-renders when parent state changes (e.g., wallpaper)
+export const DesktopIcons = memo(function DesktopIcons({
   onWallpaperChange,
 }: {
   onWallpaperChange?: (wallpaper: string) => void;
@@ -548,4 +549,4 @@ export function DesktopIcons({
       {showPranavChat && <PranavChatWindow onClose={() => setShowPranavChat(false)} />}
     </>
   );
-}
+});

--- a/app/components/ui/Quote.tsx
+++ b/app/components/ui/Quote.tsx
@@ -1,6 +1,8 @@
 import { motion } from 'framer-motion';
+import { memo } from 'react';
 
-export function Quote() {
+// Memoized to prevent re-renders when parent state changes
+export const Quote = memo(function Quote() {
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
@@ -13,4 +15,4 @@ export function Quote() {
       <p className="text-white/40 text-xs text-right">— Charles Bukowski</p>
     </motion.div>
   );
-}
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ToggleButton } from './components/ui/ButtonToggle';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import FloatingDockDemo from './components/Navbar';
 import { DesktopIcons } from './components/ui/DesktopIcons';
 import { Quote } from './components/ui/Quote';
@@ -11,19 +11,15 @@ const Terminalcomp = dynamic(() => import('./components/Terminal/Terminal'), {
   loading: () => <div className="text-white text-center">Loading Terminal...</div>,
 });
 
-const BrowserWindow = dynamic(
-  () => import('./components/windows/BrowserWindow').then(mod => mod.BrowserWindow),
-  { ssr: false }
-);
-
 export default function Home() {
   const [isCLI, setIsCLI] = useState(false);
   const [wallpaper, setWallpaper] = useState<string | null>(null);
 
-  const handleWallpaperChange = (newWallpaper: string) => {
+  // Memoize handler to prevent unnecessary re-renders of child components
+  const handleWallpaperChange = useCallback((newWallpaper: string) => {
     console.log('New wallpaper:', newWallpaper); // Debug log
     setWallpaper(newWallpaper);
-  };
+  }, []);
 
   // Add this style to your main container
   const backgroundStyle = wallpaper


### PR DESCRIPTION
💡 What: Wrapped `DesktopIcons`, `FloatingDockDemo`, and `Quote` in `React.memo` and wrapped `handleWallpaperChange` in `useCallback`. Removed unused `BrowserWindow` dynamic import.
🎯 Why: Prevents unnecessary re-renders of heavy desktop components when parent state (like wallpaper) changes, improving performance.
📊 Impact: Reduces re-renders of the entire desktop UI stack when interacting with settings/wallpaper.
🔬 Measurement: Verified with Playwright that interaction with Settings window still works correctly (double-click to open).

---
*PR created automatically by Jules for task [15728841056841448054](https://jules.google.com/task/15728841056841448054) started by @Pranav322*