### PR TITLE
feat: add keyboard focus magnification to floating dock

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,10 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Focus as Virtual Mouse
+**Learning:** UX patterns relying on mouse position (like mac-style docks) often fail for keyboard users. By treating keyboard focus as a "virtual mouse" at the element's center coordinates, we can reuse complex motion logic without duplication.
+**Action:** When using `useMotionValue` for mouse-driven layouts, implement `onFocus` handlers that programmatically set the motion value to the focused element's center (e.g., `mouseX.set(center)`) to trigger the same visual feedback.

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -127,6 +127,15 @@ const FloatingDockMobile = ({ items, className }: { items: DockItem[]; className
 
 const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; className?: string }) => {
   let mouseX = useMotionValue(Infinity);
+
+  const handleFocus = (x: number) => {
+    mouseX.set(x);
+  };
+
+  const handleBlur = () => {
+    mouseX.set(Infinity);
+  };
+
   return (
     <motion.div
       onMouseMove={e => mouseX.set(e.pageX)}
@@ -145,7 +154,13 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
       }}
     >
       {items.map(item => (
-        <IconContainer mouseX={mouseX} key={item.title} {...item} />
+        <IconContainer
+          mouseX={mouseX}
+          key={item.title}
+          {...item}
+          onFocusParent={handleFocus}
+          onBlurParent={handleBlur}
+        />
       ))}
     </motion.div>
   );
@@ -157,12 +172,16 @@ function IconContainer({
   icon,
   href,
   action,
+  onFocusParent,
+  onBlurParent,
 }: {
   mouseX: MotionValue;
   title: string;
   icon: React.ReactNode;
   href: string;
   action?: () => void;
+  onFocusParent?: (x: number) => void;
+  onBlurParent?: () => void;
 }) {
   let ref = useRef<HTMLDivElement>(null);
   let boundsRef = useRef({ x: 0, width: 0 });
@@ -215,6 +234,20 @@ function IconContainer({
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
 
+  const handleFocus = () => {
+    setFocused(true);
+    if (boundsRef.current && onFocusParent) {
+      onFocusParent(boundsRef.current.x + boundsRef.current.width / 2);
+    }
+  };
+
+  const handleBlur = () => {
+    setFocused(false);
+    if (onBlurParent) {
+      onBlurParent();
+    }
+  };
+
   const isExternal = href && href.startsWith('http');
   const isLink = isExternal || (href && href !== '#');
 
@@ -258,8 +291,8 @@ function IconContainer({
         target={isExternal ? '_blank' : undefined}
         rel={isExternal ? 'noopener noreferrer' : undefined}
         aria-label={title}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
       >
         {content}
       </Link>
@@ -272,8 +305,8 @@ function IconContainer({
       className={cn('bg-transparent border-none p-0 cursor-pointer', containerClass)}
       type="button"
       aria-label={title}
-      onFocus={() => setFocused(true)}
-      onBlur={() => setFocused(false)}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
     >
       {content}
     </button>


### PR DESCRIPTION
💡 What: Implemented keyboard focus support for the Floating Dock magnification effect.
🎯 Why: To ensure keyboard users experience the same delightful interaction as mouse users and improve accessibility.
📸 Before/After: Verified with screenshots showing the dock icons magnifying when focused via keyboard.
♿ Accessibility: Added onFocus/onBlur handlers to simulate mouse position for keyboard navigation, making the dock fully accessible.
Note: Added learning to .Jules/palette.md regarding focus-driven Framer Motion animations.

---
*PR created automatically by Jules for task [4594807796091855135](https://jules.google.com/task/4594807796091855135) started by @Pranav322*