### PR TITLE
🎨 Palette: Add accessible WindowControls and fix minimize logic

### DIFF
--- a/app/components/ui/WindowControls.tsx
+++ b/app/components/ui/WindowControls.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { IconMinus, IconSquare, IconX } from '@tabler/icons-react';
+
+interface WindowControlsProps {
+  onMinimize?: () => void;
+  onMaximize?: () => void;
+  onClose: () => void;
+  isMaximized?: boolean;
+}
+
+export function WindowControls({
+  onMinimize,
+  onMaximize,
+  onClose,
+  isMaximized,
+}: WindowControlsProps) {
+  return (
+    <div className="flex items-center gap-1">
+      {onMinimize && (
+        <motion.button
+          aria-label="Minimize window"
+          whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+          onClick={onMinimize}
+          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        >
+          <IconMinus size={14} className="text-white/80" />
+        </motion.button>
+      )}
+      {onMaximize && (
+        <motion.button
+          aria-label={isMaximized ? 'Restore window' : 'Maximize window'}
+          whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+          onClick={onMaximize}
+          className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+        >
+          <IconSquare size={14} className="text-white/80" />
+        </motion.button>
+      )}
+      <motion.button
+        aria-label="Close window"
+        whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
+        onClick={onClose}
+        className="p-2 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+      >
+        <IconX size={14} className="text-white/80" />
+      </motion.button>
+    </div>
+  );
+}

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -1,14 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconUser,
   IconBrandGithub,
   IconExternalLink,
 } from '@tabler/icons-react';
 import { motion, AnimatePresence, useDragControls } from 'framer-motion';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 import { skills } from '../helpers/Skills';
 import { projects } from '../helpers/Projects';
 import { experiences } from '../helpers/Experience';
@@ -24,6 +22,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) return null;
 
   return (
     <WindowWrapper
@@ -46,28 +46,12 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             <span className="text-white/90 text-sm font-medium">About Me</span>
           </div>
           {/* Window Controls */}
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content */}

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -1,12 +1,13 @@
 'use client';
 import { useState, useRef, useEffect } from 'react';
-import { IconX, IconMinus, IconSquare, IconBook } from '@tabler/icons-react';
+import { IconBook } from '@tabler/icons-react';
 import { motion, useDragControls, AnimatePresence } from 'framer-motion';
 import { Worker, Viewer, SpecialZoomLevel, ThemeContext } from '@react-pdf-viewer/core';
 import { defaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
 import '@react-pdf-viewer/core/lib/styles/index.css';
 import '@react-pdf-viewer/default-layout/lib/styles/index.css';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 import React from 'react';
 import Image from 'next/image';
 
@@ -110,6 +111,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
     },
   ];
 
+  if (isMinimized) return null;
+
   return (
     <WindowWrapper
       isMaximized={isMaximized}
@@ -129,28 +132,12 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Books</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content Area - Now with fixed height */}

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -1,15 +1,13 @@
 import { useState } from 'react';
 import { motion, useDragControls } from 'framer-motion';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconBrowser,
   IconArrowLeft,
   IconArrowRight,
   IconRefresh,
 } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 
 interface BrowserWindowProps {
   onClose: () => void;
@@ -57,6 +55,8 @@ export function BrowserWindow({
     setTimeout(() => setUrl(history[historyIndex]), 100);
   };
 
+  if (isMinimized) return null;
+
   return (
     <WindowWrapper
       isMaximized={isMaximized}
@@ -76,28 +76,12 @@ export function BrowserWindow({
             </div>
             <span className="text-white/90 text-sm font-medium">Browser</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Browser Controls */}

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -1,8 +1,5 @@
 import React, { useState } from 'react';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconBriefcase,
   IconMapPin,
   IconCalendar,
@@ -12,6 +9,7 @@ import {
 } from '@tabler/icons-react';
 import { motion, useDragControls } from 'framer-motion';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 import { experiences, experienceSummary } from '../helpers/Experience';
 
 interface ExperienceWindowProps {
@@ -27,6 +25,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) return null;
 
   const getTypeColor = (type: string) => {
     switch (type) {
@@ -69,29 +69,12 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
             <span className="text-white/90 text-sm font-medium">Professional Experience</span>
           </div>
           {/* Window Controls */}
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={handleMinimize}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content */}

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -2,13 +2,11 @@ import { useState } from 'react';
 import { motion, useDragControls } from 'framer-motion';
 import {
   IconDeviceGamepad2,
-  IconX,
-  IconMinus,
-  IconSquare,
   IconPlayerPlay,
   IconArrowLeft,
 } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 
 interface GamesWindowProps {
   onClose: () => void;
@@ -45,29 +43,12 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Games</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-              onClick={handleMinimize}
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         <div className="flex-1 overflow-hidden">

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { motion, useDragControls } from 'framer-motion';
-import { IconX, IconMinus, IconSquare, IconFileText } from '@tabler/icons-react';
+import { IconFileText } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 
 interface PdfWindowProps {
   onClose: () => void;
@@ -16,6 +17,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) return null;
 
   return (
     <WindowWrapper
@@ -36,28 +39,12 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Resume.pdf</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         <div className="flex-1 bg-white">

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -2,14 +2,12 @@ import React, { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useDragControls } from 'framer-motion';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconMessageCircle,
   IconSend,
   IconLoader2,
 } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 
 interface PranavChatWindowProps {
   onClose: () => void;
@@ -104,6 +102,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
     }
   };
 
+  if (isMinimized) return null;
+
   return (
     <WindowWrapper
       isMaximized={isMaximized}
@@ -124,28 +124,12 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Pranav AI</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content - matching SkillsWindow pattern */}

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -1,14 +1,12 @@
 import { useState, useRef, useEffect } from 'react';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconFolder,
   IconBrandGithub,
   IconExternalLink,
 } from '@tabler/icons-react';
 import { motion, useDragControls, AnimatePresence } from 'framer-motion';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 import { projects } from '../helpers/Projects';
 interface ProjectsWindowProps {
   onClose: () => void;
@@ -21,6 +19,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) return null;
 
   return (
     <WindowWrapper
@@ -41,28 +41,12 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Projects</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content Area */}

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -2,9 +2,6 @@ import React, { useState, useCallback, useMemo, memo } from 'react';
 import { motion } from 'framer-motion';
 import { useDragControls } from 'framer-motion';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconSettings,
   IconUpload,
   IconWallpaper,
@@ -14,6 +11,7 @@ import {
   IconCheck,
 } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 import Image from 'next/image';
 import { useTheme } from '../../contexts/ThemeContext';
 
@@ -308,29 +306,12 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             </div>
             <span className="text-white/90 text-sm font-medium">Settings</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={handleMinimize}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content with Sidebar */}

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useDragControls } from 'framer-motion';
-import { IconX, IconMinus, IconSquare, IconTools } from '@tabler/icons-react';
+import { IconTools } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 import { skills } from '../helpers/Skills';
 interface SkillsWindowProps {
   onClose: () => void;
@@ -15,6 +16,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) return null;
 
   const container = {
     hidden: { opacity: 0 },
@@ -50,28 +53,12 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Skills</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         <div className="p-3 sm:p-6 h-[calc(100%-3rem)] overflow-y-auto custom-scrollbar mobile-hide-scrollbar">


### PR DESCRIPTION
**💡 What:**
- Added a reusable `WindowControls` component with proper ARIA labels ("Minimize window", "Maximize window", "Close window") and keyboard focus styles.
- Replaced hardcoded control buttons in `AboutWindow`, `SettingsWindow`, `SkillsWindow`, `ProjectsWindow`, `ExperienceWindow`, `GamesWindow`, `BooksWindow`, `PdfWindow`, `PranavChatWindow`, and `BrowserWindow` with this new component.
- **Fixed a functional bug:** Most windows had `handleMinimize` functions that updated state but didn't actually hide the window content. Added `if (isMinimized) return null;` to all affected components.

**🎯 Why:**
- To improve accessibility for users relying on screen readers or keyboard navigation (previously buttons were icon-only divs/buttons without labels).
- To fix the broken "Minimize" functionality found in most windows.
- To reduce code duplication and ensure consistent UI behavior.

**📸 Before/After:**
- **Before:** Buttons were just icons, minimize often did nothing.
- **After:** Buttons have tooltips/labels (via ARIA), focus rings, and minimize successfully hides the window.

**♿ Accessibility:**
- Added `aria-label` to all window control buttons.
- Added `focus-visible` styles for better keyboard navigation visibility.

---
*PR created automatically by Jules for task [2946969105653628375](https://jules.google.com/task/2946969105653628375) started by @Pranav322*