### PR TITLE
⚡ Bolt: Minimize unnecessary re-renders in DesktopIcons and FloatingDock

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, memo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -36,45 +36,49 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
-    {
-      title: 'Home',
-      icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: '#',
-    },
-    {
-      title: 'Settings',
-      icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: '#',
-      action: () => setShowSettings(true),
-    },
-    // {
-    //   title: 'Components',
-    //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-    //   href: '#',
-    // },
-    {
-      title: 'Games',
-      icon: (
-        <IconDeviceGamepad2
-          size={24}
-          className="h-full w-full text-neutral-500 dark:text-neutral-300"
-        />
-      ),
-      href: '#',
-      action: () => setShowGames(true),
-    },
-    {
-      title: 'Twitter',
-      icon: <IconBrandX className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: 'https://x.com/_pranav69',
-    },
-    {
-      title: 'GitHub',
-      icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: 'https://github.com/pranav322',
-    },
-  ];
+  const links = useMemo(
+    // Memoized to prevent re-creation of links array on every render
+    () => [
+      {
+        title: 'Home',
+        icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: '#',
+      },
+      {
+        title: 'Settings',
+        icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: '#',
+        action: () => setShowSettings(true),
+      },
+      // {
+      //   title: 'Components',
+      //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+      //   href: '#',
+      // },
+      {
+        title: 'Games',
+        icon: (
+          <IconDeviceGamepad2
+            size={24}
+            className="h-full w-full text-neutral-500 dark:text-neutral-300"
+          />
+        ),
+        href: '#',
+        action: () => setShowGames(true),
+      },
+      {
+        title: 'Twitter',
+        icon: <IconBrandX className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: 'https://x.com/_pranav69',
+      },
+      {
+        title: 'GitHub',
+        icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: 'https://github.com/pranav322',
+      },
+    ],
+    []
+  );
 
   return (
     <>
@@ -95,4 +99,5 @@ function FloatingDockDemo({
   );
 }
 
-export default FloatingDockDemo;
+// Memoized to prevent re-renders when parent state updates (e.g. wallpaper)
+export default memo(FloatingDockDemo);

--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useMemo, memo } from 'react';
 import { AnimatePresence } from 'framer-motion';
 
 // Hook to detect device types
@@ -149,7 +149,8 @@ const handlePrefetch = (iconName: string) => {
 };
 import { useTheme } from '../../contexts/ThemeContext';
 
-export function DesktopIcons({
+// Memoized to prevent re-renders when Home component state updates (e.g. wallpaper changes)
+export const DesktopIcons = memo(function DesktopIcons({
   onWallpaperChange,
 }: {
   onWallpaperChange?: (wallpaper: string) => void;
@@ -548,4 +549,4 @@ export function DesktopIcons({
       {showPranavChat && <PranavChatWindow onClose={() => setShowPranavChat(false)} />}
     </>
   );
-}
+});

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, memo } from 'react';
 
 interface DockItem {
   title: string;
@@ -151,7 +151,8 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+// Memoized to prevent expensive Framer Motion hook re-computations when parent re-renders
+const IconContainer = memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +279,4 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ToggleButton } from './components/ui/ButtonToggle';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import FloatingDockDemo from './components/Navbar';
 import { DesktopIcons } from './components/ui/DesktopIcons';
 import { Quote } from './components/ui/Quote';
@@ -20,10 +20,11 @@ export default function Home() {
   const [isCLI, setIsCLI] = useState(false);
   const [wallpaper, setWallpaper] = useState<string | null>(null);
 
-  const handleWallpaperChange = (newWallpaper: string) => {
+  const handleWallpaperChange = useCallback((newWallpaper: string) => {
+    // Memoized to prevent re-renders of child components like DesktopIcons and FloatingDock
     console.log('New wallpaper:', newWallpaper); // Debug log
     setWallpaper(newWallpaper);
-  };
+  }, []);
 
   // Add this style to your main container
   const backgroundStyle = wallpaper


### PR DESCRIPTION
💡 What: Wrapped `DesktopIcons` and `FloatingDockDemo` in `React.memo`. Memoized `links` array in `FloatingDockDemo` and `handleWallpaperChange` in `Home`. Memoized `IconContainer` in `floating-dock.tsx`.
🎯 Why: Changing `Home` state (like wallpaper or toggling CLI) caused unnecessary re-renders of heavy components like `DesktopIcons` and `FloatingDock`, leading to performance degradation, especially with Framer Motion animations.
📊 Impact: Reduces re-renders of `DesktopIcons` and `FloatingDock` to zero when unrelated `Home` state changes. `IconContainer` re-renders are minimized.
🔬 Measurement: Verified with Playwright that components still render and interact correctly. Visual inspection confirms no regressions.

---
*PR created automatically by Jules for task [13167711515193627506](https://jules.google.com/task/13167711515193627506) started by @Pranav322*