### PR TITLE
🎨 Palette: Improve window controls UX and accessibility

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -35,6 +35,12 @@ function FloatingDockDemo({
 }: FloatingDockDemoProps) {
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
+  const [windowKeys, setWindowKeys] = useState<Record<string, number>>({});
+
+  const handleOpen = (name: string, setShow: (val: boolean) => void) => {
+    setWindowKeys(prev => ({ ...prev, [name]: (prev[name] || 0) + 1 }));
+    setShow(true);
+  };
 
   const links = [
     {
@@ -46,7 +52,7 @@ function FloatingDockDemo({
       title: 'Settings',
       icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: '#',
-      action: () => setShowSettings(true),
+      action: () => handleOpen('Settings', setShowSettings),
     },
     // {
     //   title: 'Components',
@@ -62,7 +68,7 @@ function FloatingDockDemo({
         />
       ),
       href: '#',
-      action: () => setShowGames(true),
+      action: () => handleOpen('Games', setShowGames),
     },
     {
       title: 'Twitter',
@@ -86,11 +92,17 @@ function FloatingDockDemo({
 
       {showSettings && (
         <SettingsWindow
+          key={`settings-${windowKeys['Settings'] || 0}`}
           onClose={() => setShowSettings(false)}
           onWallpaperChange={onWallpaperChange}
         />
       )}
-      {showGames && <GamesWindow onClose={() => setShowGames(false)} />}
+      {showGames && (
+        <GamesWindow
+          key={`games-${windowKeys['Games'] || 0}`}
+          onClose={() => setShowGames(false)}
+        />
+      )}
     </>
   );
 }

--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -157,6 +157,7 @@ export function DesktopIcons({
   const { deviceType, windowSize } = useDeviceType();
   const { currentTheme } = useTheme();
   const [selectedIcon, setSelectedIcon] = useState<string | null>(null);
+  const [windowKeys, setWindowKeys] = useState<Record<string, number>>({});
   const [showAbout, setShowAbout] = useState(false);
   const [showBooks, setShowBooks] = useState(false);
   const [showProjects, setShowProjects] = useState(false);
@@ -174,6 +175,7 @@ export function DesktopIcons({
   const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const openApp = (iconName: string, action?: () => void) => {
+    setWindowKeys(prev => ({ ...prev, [iconName]: (prev[iconName] || 0) + 1 }));
     if (action) {
       action();
     } else {
@@ -526,26 +528,66 @@ export function DesktopIcons({
         )}
       </AnimatePresence>
 
-      {showAbout && <AboutWindow onClose={() => setShowAbout(false)} />}
-      {showBooks && <BooksWindow onClose={() => setShowBooks(false)} />}
-      {showProjects && <ProjectsWindow onClose={() => setShowProjects(false)} />}
-      {showSkills && <SkillsWindow onClose={() => setShowSkills(false)} />}
+      {showAbout && (
+        <AboutWindow
+          key={`about-${windowKeys['About Me'] || 0}`}
+          onClose={() => setShowAbout(false)}
+        />
+      )}
+      {showBooks && (
+        <BooksWindow key={`books-${windowKeys['Books'] || 0}`} onClose={() => setShowBooks(false)} />
+      )}
+      {showProjects && (
+        <ProjectsWindow
+          key={`projects-${windowKeys['Projects'] || 0}`}
+          onClose={() => setShowProjects(false)}
+        />
+      )}
+      {showSkills && (
+        <SkillsWindow
+          key={`skills-${windowKeys['Skills'] || 0}`}
+          onClose={() => setShowSkills(false)}
+        />
+      )}
       {showSettings && (
         <SettingsWindow
+          key={`settings-${windowKeys['Settings'] || 0}`}
           onClose={() => setShowSettings(false)}
           onWallpaperChange={onWallpaperChange!}
         />
       )}
       {showBrowser && (
         <BrowserWindow
+          key={`browser-${windowKeys['Browser'] || 0}`}
           initialUrl="https://iframee.vercel.app"
           onClose={() => setShowBrowser(false)}
         />
       )}
-      {showSpotify && <SpotifyWindow onClose={() => setShowSpotify(false)} />}
-      {showPdf && <PdfWindow filePath="/backend_dev.pdf" onClose={() => setShowPdf(false)} />}
-      {showExperience && <ExperienceWindow onClose={() => setShowExperience(false)} />}
-      {showPranavChat && <PranavChatWindow onClose={() => setShowPranavChat(false)} />}
+      {showSpotify && (
+        <SpotifyWindow
+          key={`spotify-${windowKeys['My Spotify'] || 0}`}
+          onClose={() => setShowSpotify(false)}
+        />
+      )}
+      {showPdf && (
+        <PdfWindow
+          key={`pdf-${windowKeys['Resume'] || 0}`}
+          filePath="/backend_dev.pdf"
+          onClose={() => setShowPdf(false)}
+        />
+      )}
+      {showExperience && (
+        <ExperienceWindow
+          key={`experience-${windowKeys['Experience'] || 0}`}
+          onClose={() => setShowExperience(false)}
+        />
+      )}
+      {showPranavChat && (
+        <PranavChatWindow
+          key={`chat-${windowKeys['Pranav AI'] || 0}`}
+          onClose={() => setShowPranavChat(false)}
+        />
+      )}
     </>
   );
 }

--- a/app/components/ui/WindowControls.tsx
+++ b/app/components/ui/WindowControls.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { IconMinus, IconSquare, IconX } from '@tabler/icons-react';
+
+interface WindowControlsProps {
+  onMinimize: () => void;
+  onMaximize: () => void;
+  onClose: () => void;
+  isMaximized: boolean;
+}
+
+export function WindowControls({
+  onMinimize,
+  onMaximize,
+  onClose,
+  isMaximized,
+}: WindowControlsProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <motion.button
+        whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+        onClick={onMinimize}
+        className="p-2 rounded-full"
+        aria-label="Minimize window"
+      >
+        <IconMinus size={14} className="text-white/80" />
+      </motion.button>
+      <motion.button
+        whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+        onClick={onMaximize}
+        className="p-2 rounded-full"
+        aria-label={isMaximized ? 'Restore window' : 'Maximize window'}
+      >
+        <IconSquare size={14} className="text-white/80" />
+      </motion.button>
+      <motion.button
+        whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
+        onClick={onClose}
+        className="p-2 rounded-full"
+        aria-label="Close window"
+      >
+        <IconX size={14} className="text-white/80" />
+      </motion.button>
+    </div>
+  );
+}

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -1,8 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconUser,
   IconBrandGithub,
   IconExternalLink,
@@ -12,6 +9,8 @@ import { WindowWrapper } from '../ui/WindowWrapper';
 import { skills } from '../helpers/Skills';
 import { projects } from '../helpers/Projects';
 import { experiences } from '../helpers/Experience';
+import { WindowControls } from '../ui/WindowControls';
+
 interface AboutWindowProps {
   onClose: () => void;
 }
@@ -24,6 +23,10 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) {
+    return null;
+  }
 
   return (
     <WindowWrapper
@@ -46,28 +49,12 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             <span className="text-white/90 text-sm font-medium">About Me</span>
           </div>
           {/* Window Controls */}
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content */}

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -1,12 +1,13 @@
 'use client';
 import { useState, useRef, useEffect } from 'react';
-import { IconX, IconMinus, IconSquare, IconBook } from '@tabler/icons-react';
+import { IconBook } from '@tabler/icons-react';
 import { motion, useDragControls, AnimatePresence } from 'framer-motion';
 import { Worker, Viewer, SpecialZoomLevel, ThemeContext } from '@react-pdf-viewer/core';
 import { defaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
 import '@react-pdf-viewer/core/lib/styles/index.css';
 import '@react-pdf-viewer/default-layout/lib/styles/index.css';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 import React from 'react';
 import Image from 'next/image';
 
@@ -110,6 +111,10 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
     },
   ];
 
+  if (isMinimized) {
+    return null;
+  }
+
   return (
     <WindowWrapper
       isMaximized={isMaximized}
@@ -129,28 +134,12 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Books</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content Area - Now with fixed height */}

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -1,8 +1,5 @@
 import React, { useState } from 'react';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconBriefcase,
   IconMapPin,
   IconCalendar,
@@ -13,6 +10,7 @@ import {
 import { motion, useDragControls } from 'framer-motion';
 import { WindowWrapper } from '../ui/WindowWrapper';
 import { experiences, experienceSummary } from '../helpers/Experience';
+import { WindowControls } from '../ui/WindowControls';
 
 interface ExperienceWindowProps {
   onClose: () => void;
@@ -27,6 +25,10 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) {
+    return null;
+  }
 
   const getTypeColor = (type: string) => {
     switch (type) {
@@ -69,29 +71,12 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
             <span className="text-white/90 text-sm font-medium">Professional Experience</span>
           </div>
           {/* Window Controls */}
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={handleMinimize}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content */}

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -2,13 +2,11 @@ import { useState } from 'react';
 import { motion, useDragControls } from 'framer-motion';
 import {
   IconDeviceGamepad2,
-  IconX,
-  IconMinus,
-  IconSquare,
   IconPlayerPlay,
   IconArrowLeft,
 } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 
 interface GamesWindowProps {
   onClose: () => void;
@@ -45,29 +43,12 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Games</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-              onClick={handleMinimize}
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         <div className="flex-1 overflow-hidden">

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -2,14 +2,12 @@ import React, { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useDragControls } from 'framer-motion';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconMessageCircle,
   IconSend,
   IconLoader2,
 } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 
 interface PranavChatWindowProps {
   onClose: () => void;
@@ -54,6 +52,10 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
   useEffect(() => {
     scrollToBottom();
   }, [messages]);
+
+  if (isMinimized) {
+    return null;
+  }
 
   const sendMessage = async () => {
     if (!input.trim() || isLoading) return;
@@ -124,28 +126,12 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Pranav AI</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content - matching SkillsWindow pattern */}

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -1,8 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconFolder,
   IconBrandGithub,
   IconExternalLink,
@@ -10,6 +7,8 @@ import {
 import { motion, useDragControls, AnimatePresence } from 'framer-motion';
 import { WindowWrapper } from '../ui/WindowWrapper';
 import { projects } from '../helpers/Projects';
+import { WindowControls } from '../ui/WindowControls';
+
 interface ProjectsWindowProps {
   onClose: () => void;
 }
@@ -21,6 +20,10 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) {
+    return null;
+  }
 
   return (
     <WindowWrapper
@@ -41,28 +44,12 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Projects</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content Area */}

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -2,9 +2,6 @@ import React, { useState, useCallback, useMemo, memo } from 'react';
 import { motion } from 'framer-motion';
 import { useDragControls } from 'framer-motion';
 import {
-  IconX,
-  IconMinus,
-  IconSquare,
   IconSettings,
   IconUpload,
   IconWallpaper,
@@ -14,6 +11,7 @@ import {
   IconCheck,
 } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
+import { WindowControls } from '../ui/WindowControls';
 import Image from 'next/image';
 import { useTheme } from '../../contexts/ThemeContext';
 
@@ -308,29 +306,12 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             </div>
             <span className="text-white/90 text-sm font-medium">Settings</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={handleMinimize}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         {/* Content with Sidebar */}

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useDragControls } from 'framer-motion';
-import { IconX, IconMinus, IconSquare, IconTools } from '@tabler/icons-react';
+import { IconTools } from '@tabler/icons-react';
 import { WindowWrapper } from '../ui/WindowWrapper';
 import { skills } from '../helpers/Skills';
+import { WindowControls } from '../ui/WindowControls';
+
 interface SkillsWindowProps {
   onClose: () => void;
 }
@@ -15,6 +17,10 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
   const handleMinimize = () => {
     setIsMinimized(true);
   };
+
+  if (isMinimized) {
+    return null;
+  }
 
   const container = {
     hidden: { opacity: 0 },
@@ -50,28 +56,12 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             </div>
             <span className="text-white/90 text-sm font-medium">Skills</span>
           </div>
-          <div className="flex items-center gap-1">
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
-            >
-              <IconMinus size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
-            >
-              <IconSquare size={14} className="text-white/80" />
-            </motion.button>
-            <motion.button
-              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
-              onClick={onClose}
-              className="p-2 rounded-full"
-            >
-              <IconX size={14} className="text-white/80" />
-            </motion.button>
-          </div>
+          <WindowControls
+            onMinimize={handleMinimize}
+            onMaximize={() => setIsMaximized(!isMaximized)}
+            onClose={onClose}
+            isMaximized={isMaximized}
+          />
         </motion.div>
 
         <div className="p-3 sm:p-6 h-[calc(100%-3rem)] overflow-y-auto custom-scrollbar mobile-hide-scrollbar">


### PR DESCRIPTION
💡 What: Refactored window controls into a reusable `WindowControls` component with proper ARIA labels and consistent styling. Fixed the broken "Minimize" functionality by ensuring windows hide when minimized and can be restored by clicking their desktop or dock icon.

🎯 Why:
- The "Minimize" button was broken in multiple windows (Skills, About, Projects, Chat), leading to a confusing UX where clicking it did nothing.
- Window controls lacked accessibility labels (ARIA), making them unusable for screen readers.
- Duplicated code for window headers made maintenance difficult and prone to inconsistencies.
- Minimized windows could not be restored easily.

📸 Before/After:
- Before: Clicking minimize did nothing in most windows. Buttons had no labels.
- After: Clicking minimize hides the window. Clicking the desktop icon restores it. Buttons have "Minimize window", "Maximize window", "Close window" labels.

♿ Accessibility:
- Added `aria-label` to all window control buttons.
- ensured consistent keyboard focus indicators (via existing styles).

---
*PR created automatically by Jules for task [14980326933165821650](https://jules.google.com/task/14980326933165821650) started by @Pranav322*