### PR TITLE
⚡ Bolt: Optimize Terminal Rendering

### DIFF
--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -3,14 +3,44 @@ import { TerminalSquare } from 'lucide-react';
 import { safeEvaluate } from '@/lib/math';
 import { getFormattedTime } from '@/lib/utils';
 
-const TerminalClock = () => {
+const TerminalClock = React.memo(() => {
   const [time, setTime] = useState(getFormattedTime());
   useEffect(() => {
     const timer = setInterval(() => setTime(getFormattedTime()), 1000);
     return () => clearInterval(timer);
   }, []);
   return <div className="text-xs mb-2 sm:mb-4 opacity-70">Last login: {time}</div>;
-};
+});
+TerminalClock.displayName = 'TerminalClock';
+
+interface TerminalCommandItemProps {
+  command: {
+    id: number;
+    input: string;
+    time: string;
+    output: React.ReactNode;
+    directory: string;
+  };
+  userName: string;
+}
+
+const TerminalCommandItem = React.memo(({ command, userName }: TerminalCommandItemProps) => {
+  return (
+    <div className="mb-2 sm:mb-4" suppressHydrationWarning>
+      <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
+        <span className="text-green-500">{userName || 'guest'}@portfolio</span>
+        <span className="text-blue-400">:</span>
+        <span className="text-blue-400">{command.directory || '~'}</span>
+        <span className="text-white">$</span>
+        <span className="text-white break-all">{command.input}</span>
+      </div>
+      <div className="mt-1 text-xs sm:text-sm text-gray-300 break-words whitespace-pre-wrap">
+        {command.output}
+      </div>
+    </div>
+  );
+});
+TerminalCommandItem.displayName = 'TerminalCommandItem';
 
 const Terminalcomp = () => {
   const [input, setInput] = useState('');
@@ -492,23 +522,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
-              <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
-                <span className="text-green-500">{userName || 'guest'}@portfolio</span>
-                <span className="text-blue-400">:</span>
-                <span className="text-blue-400">{command.directory || '~'}</span>
-                <span className="text-white">$</span>
-                <span className="text-white break-all">{command.input}</span>
-              </div>
-              <div className="mt-1 text-xs sm:text-sm text-gray-300 break-words whitespace-pre-wrap">
-                {command.output}
-              </div>
-            </div>
+            <TerminalCommandItem key={command.id} command={command} userName={userName} />
           ))}
 
           {isAskingName && (
@@ -516,7 +530,10 @@ const Terminalcomp = () => {
               Please enter your name to continue:
             </div>
           )}
-          <div className="flex items-center gap-1 sm:gap-2 text-xs sm:text-sm">
+          <div
+            ref={terminalRef}
+            className="flex items-center gap-1 sm:gap-2 text-xs sm:text-sm"
+          >
             <span className="text-green-500">{userName || 'guest'}@portfolio</span>
             <span className="text-blue-400">:</span>
             <span className="text-blue-400">{currentDirectory}</span>


### PR DESCRIPTION
💡 What: Extracted `TerminalCommandItem` and `TerminalClock` into memoized components in `Terminal.tsx`. Moved the scrolling ref to the input container.
🎯 Why: `Terminalcomp` was re-rendering the entire command history on every keystroke, causing O(N) performance cost where N is the number of commands.
📊 Impact: Reduces re-renders of command items to 0 during typing. Transforms render cost from O(N) to O(1).
🔬 Measurement: Verified with `pnpm lint` and `pnpm exec tsc --noEmit`. Verified functionality with Playwright script.

---
*PR created automatically by Jules for task [11383031222787910462](https://jules.google.com/task/11383031222787910462) started by @Pranav322*