### PR TITLE
🎨 Palette: Added ARIA labels to window controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-03-01 - Missing ARIA Labels in Duplicated UI
+**Learning:** Found a recurring a11y issue where all desktop window components (11 files) duplicated their header controls (Minimize/Maximize/Close) without ARIA labels, making them invisible to screen readers. This indicates a missed opportunity to centralize window controls into a shared `WindowControls` component for better maintainability and accessibility.
+**Action:** When creating windowing systems or similar repeated UI, centralize interactive controls early to ensure accessibility improvements (like ARIA labels) propagate everywhere instantly.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -47,20 +47,20 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           </div>
           {/* Window Controls */}
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -130,20 +130,20 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             <span className="text-white/90 text-sm font-medium">Books</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -77,20 +77,20 @@ export function BrowserWindow({
             <span className="text-white/90 text-sm font-medium">Browser</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -70,21 +70,21 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
           </div>
           {/* Window Controls */}
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -46,21 +46,21 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             <span className="text-white/90 text-sm font-medium">Games</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
               onClick={handleMinimize}
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -37,20 +37,20 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             <span className="text-white/90 text-sm font-medium">Resume.pdf</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -125,20 +125,20 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             <span className="text-white/90 text-sm font-medium">Pranav AI</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -42,20 +42,20 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             <span className="text-white/90 text-sm font-medium">Projects</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -309,21 +309,21 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             <span className="text-white/90 text-sm font-medium">Settings</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -51,20 +51,20 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             <span className="text-white/90 text-sm font-medium">Skills</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -39,19 +39,19 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
             <span className="text-white/90 text-sm font-medium">Spotify Stats</span>
           </div>
           <div className="flex items-center gap-4">
-            <button
+            <button aria-label="Minimize"
               onClick={handleMinimize}
               className="text-white/50 hover:text-white transition-colors"
             >
               <IconMinus size={18} />
             </button>
-            <button
+            <button aria-label="Maximize"
               onClick={toggleMaximize}
               className="text-white/50 hover:text-white transition-colors"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button aria-label="Close" onClick={onClose} className="text-white/50 hover:text-white transition-colors">
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
🎨 **Palette: Added ARIA labels to icon-only window buttons**

💡 **What:** Added `aria-label="Minimize"`, `aria-label="Maximize"`, and `aria-label="Close"` to the icon-only window control buttons (`IconMinus`, `IconSquare`, `IconX`) across all 11 desktop window components in `app/components/windows/`.
🎯 **Why:** To improve the accessibility for screen reader users by providing semantic meaning to these interactive elements that previously relied entirely on visual cues (icons) without text equivalents.
♿ **Accessibility:** This directly addresses the missing ARIA labels on icon-only buttons. Added a learning to `.Jules/palette.md` about centralizing these controls to prevent this common a11y gap.

---
*PR created automatically by Jules for task [11084122193537579995](https://jules.google.com/task/11084122193537579995) started by @Pranav322*