### PR TITLE
⚡ Bolt: Memoize heavy Framer Motion component trees

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-12 - [Memoizing Framer Motion Component Trees]
+**Learning:** When using Framer Motion hooks like `useSpring` and `useTransform` in heavy component trees (e.g. `FloatingDock` and `DesktopIcons`), any state change in a parent component (like `Home` updating `wallpaper` state) causes a complete re-render and recalculation of these expensive animation hooks.
+**Action:** Always strictly memoize `React` elements that wrap these hooks using `React.memo`, ensure complex arrays of objects passed to them are memoized with `useMemo`, and wrap any event handlers passed as props (e.g. `handleWallpaperChange`) with `useCallback` to maintain referential stability.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, memo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -28,7 +28,7 @@ interface FloatingDockDemoProps {
   onWallpaperChange: (wallpaper: string) => void;
 }
 
-function FloatingDockDemo({
+const FloatingDockDemo = memo(function FloatingDockDemo({
   desktopClassName,
   mobileClassName,
   onWallpaperChange,
@@ -36,7 +36,7 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
+  const links = useMemo(() => [
     {
       title: 'Home',
       icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
@@ -74,7 +74,7 @@ function FloatingDockDemo({
       icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: 'https://github.com/pranav322',
     },
-  ];
+  ], []);
 
   return (
     <>
@@ -93,6 +93,6 @@ function FloatingDockDemo({
       {showGames && <GamesWindow onClose={() => setShowGames(false)} />}
     </>
   );
-}
+});
 
 export default FloatingDockDemo;

--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useMemo, memo } from 'react';
 import { AnimatePresence } from 'framer-motion';
 
 // Hook to detect device types
@@ -149,7 +149,7 @@ const handlePrefetch = (iconName: string) => {
 };
 import { useTheme } from '../../contexts/ThemeContext';
 
-export function DesktopIcons({
+export const DesktopIcons = memo(function DesktopIcons({
   onWallpaperChange,
 }: {
   onWallpaperChange?: (wallpaper: string) => void;
@@ -548,4 +548,4 @@ export function DesktopIcons({
       {showPranavChat && <PranavChatWindow onClose={() => setShowPranavChat(false)} />}
     </>
   );
-}
+});

--- a/app/components/ui/Quote.tsx
+++ b/app/components/ui/Quote.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
+import { memo } from 'react';
 
-export function Quote() {
+export const Quote = memo(function Quote() {
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
@@ -13,4 +14,4 @@ export function Quote() {
       <p className="text-white/40 text-xs text-right">— Charles Bukowski</p>
     </motion.div>
   );
-}
+});

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, memo } from 'react';
 
 interface DockItem {
   title: string;
@@ -151,7 +151,7 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+const IconContainer = memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +278,4 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ToggleButton } from './components/ui/ButtonToggle';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import FloatingDockDemo from './components/Navbar';
 import { DesktopIcons } from './components/ui/DesktopIcons';
 import { Quote } from './components/ui/Quote';
@@ -20,10 +20,12 @@ export default function Home() {
   const [isCLI, setIsCLI] = useState(false);
   const [wallpaper, setWallpaper] = useState<string | null>(null);
 
-  const handleWallpaperChange = (newWallpaper: string) => {
+  // Memoize handleWallpaperChange to prevent cascading re-renders in heavy children components
+  // like DesktopIcons and FloatingDockDemo
+  const handleWallpaperChange = useCallback((newWallpaper: string) => {
     console.log('New wallpaper:', newWallpaper); // Debug log
     setWallpaper(newWallpaper);
-  };
+  }, []);
 
   // Add this style to your main container
   const backgroundStyle = wallpaper


### PR DESCRIPTION
💡 **What:** Added `React.memo`, `useCallback`, and `useMemo` optimizations to the core layout components (`Home`, `DesktopIcons`, `FloatingDockDemo`, `IconContainer`, `Quote`).

🎯 **Why:** The `Home` component manages the `wallpaper` state. Prior to this PR, whenever `setWallpaper` was called (e.g., from the Settings window), it caused the entire layout tree to re-render. Since components like `DesktopIcons` and `FloatingDock` utilize expensive Framer Motion animation hooks (`useSpring`, `useTransform`) bound to mouse movement, these unneeded re-renders were extremely costly and could cause layout thrashing or stuttering. 

📊 **Impact:** Drastically reduces re-renders on the main page. Changing the wallpaper or toggling UI states now only re-renders the necessary components, saving significant JavaScript execution time by skipping Framer Motion recalculations for the dock.

🔬 **Measurement:** You can verify this by checking the React DevTools Profiler while changing the wallpaper; the `DesktopIcons` and `FloatingDockDemo` will be grayed out (memoized) rather than showing rendering time.

---
*PR created automatically by Jules for task [3376807173448217762](https://jules.google.com/task/3376807173448217762) started by @Pranav322*