### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders of heavy UI components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [React.memo and Object Props]
+**Learning:** When using React.memo to prevent re-renders on heavy UI components like DesktopIcons or FloatingDockDemo, it is not enough to just wrap the component itself. You must ensure that any objects, arrays, or functions passed to them as props maintain referential equality across renders using useMemo or useCallback. Otherwise, a new reference is generated on every render of the parent component, completely bypassing the React.memo optimization and causing the child component to re-render anyway.
+**Action:** Always check the props of a memoized component. Wrap inline arrays or objects with useMemo and inline functions with useCallback at the parent level before passing them down.


### PR DESCRIPTION
⚡ Bolt: Prevent unnecessary re-renders of heavy UI components

💡 What: Wrapped `DesktopIcons`, `FloatingDockDemo`, `Quote`, and `IconContainer` in `React.memo`. Memoized `handleWallpaperChange` (with `useCallback`) and `links` array (with `useMemo`) to stabilize prop references passed to these heavy components.
🎯 Why: State changes in the parent `Home` component (like `isCLI` or `wallpaper`) were causing cascading, expensive re-renders of child UI components and their nested Framer Motion hooks, even when their specific props had not changed.
📊 Impact: Significantly reduces React render cycle overhead and prevents layout/animation thrashing on the main thread during state updates in the `Home` component.
🔬 Measurement: Can be verified by profiling component re-renders in React DevTools; `DesktopIcons` and `FloatingDockDemo` will no longer render when `isCLI` is toggled.

---
*PR created automatically by Jules for task [1087880057180422760](https://jules.google.com/task/1087880057180422760) started by @Pranav322*