### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders of expensive Framer Motion components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Expensive Framer Motion Hooks Require Strict Memoization
+**Learning:** Components using expensive Framer Motion hooks (`useSpring`, `useTransform`) like `IconContainer` in `floating-dock.tsx` will cause severe performance degradation if they re-render on parent state updates (like `Home` component's `isCLI` or `wallpaper`). Passing unmemoized arrays (like `links`) or functions to these components triggers unnecessary re-renders.
+**Action:** Always wrap heavy interactive components (like `DesktopIcons`, `FloatingDock`, `Quote`) in `React.memo` and strictly memoize their props using `useMemo` for arrays/objects and `useCallback` for functions passed from parent components to prevent layout thrashing and garbage collection overhead.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, memo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -28,7 +28,8 @@ interface FloatingDockDemoProps {
   onWallpaperChange: (wallpaper: string) => void;
 }
 
-function FloatingDockDemo({
+// ⚡ Bolt: Prevent unnecessary re-renders of the entire dock structure
+const FloatingDockDemo = memo(function FloatingDockDemo({
   desktopClassName,
   mobileClassName,
   onWallpaperChange,
@@ -36,7 +37,8 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
+  // ⚡ Bolt: Memoize the links array to maintain referential stability for FloatingDock
+  const links = useMemo(() => [
     {
       title: 'Home',
       icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
@@ -74,7 +76,7 @@ function FloatingDockDemo({
       icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: 'https://github.com/pranav322',
     },
-  ];
+  ], []);
 
   return (
     <>
@@ -93,6 +95,6 @@ function FloatingDockDemo({
       {showGames && <GamesWindow onClose={() => setShowGames(false)} />}
     </>
   );
-}
+});
 
 export default FloatingDockDemo;

--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useMemo, memo } from 'react';
 import { AnimatePresence } from 'framer-motion';
 
 // Hook to detect device types
@@ -149,7 +149,8 @@ const handlePrefetch = (iconName: string) => {
 };
 import { useTheme } from '../../contexts/ThemeContext';
 
-export function DesktopIcons({
+// ⚡ Bolt: Prevent unnecessary re-renders of heavy icon components and window mounts
+export const DesktopIcons = memo(function DesktopIcons({
   onWallpaperChange,
 }: {
   onWallpaperChange?: (wallpaper: string) => void;
@@ -548,4 +549,4 @@ export function DesktopIcons({
       {showPranavChat && <PranavChatWindow onClose={() => setShowPranavChat(false)} />}
     </>
   );
-}
+});

--- a/app/components/ui/Quote.tsx
+++ b/app/components/ui/Quote.tsx
@@ -1,6 +1,8 @@
 import { motion } from 'framer-motion';
+import { memo } from 'react';
 
-export function Quote() {
+// ⚡ Bolt: Prevent unnecessary re-renders since this is a static visual component
+export const Quote = memo(function Quote() {
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
@@ -13,4 +15,4 @@ export function Quote() {
       <p className="text-white/40 text-xs text-right">— Charles Bukowski</p>
     </motion.div>
   );
-}
+});

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, memo } from 'react';
 
 interface DockItem {
   title: string;
@@ -24,7 +24,8 @@ interface DockItem {
   action?: () => void;
 }
 
-export const FloatingDock = ({
+// ⚡ Bolt: Prevent unnecessary re-renders of the entire dock structure
+export const FloatingDock = memo(function FloatingDock({
   items,
   desktopClassName,
   mobileClassName,
@@ -32,14 +33,14 @@ export const FloatingDock = ({
   items: DockItem[];
   desktopClassName?: string;
   mobileClassName?: string;
-}) => {
+}) {
   return (
     <>
       <FloatingDockDesktop items={items} className={desktopClassName} />
       <FloatingDockMobile items={items} className={mobileClassName} />
     </>
   );
-};
+});
 
 const FloatingDockMobile = ({ items, className }: { items: DockItem[]; className?: string }) => {
   const [open, setOpen] = useState(false);
@@ -151,7 +152,8 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+// ⚡ Bolt: Prevent performance degradation caused by re-rendering expensive Framer Motion hooks
+const IconContainer = memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +280,4 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ToggleButton } from './components/ui/ButtonToggle';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import FloatingDockDemo from './components/Navbar';
 import { DesktopIcons } from './components/ui/DesktopIcons';
 import { Quote } from './components/ui/Quote';
@@ -20,10 +20,11 @@ export default function Home() {
   const [isCLI, setIsCLI] = useState(false);
   const [wallpaper, setWallpaper] = useState<string | null>(null);
 
-  const handleWallpaperChange = (newWallpaper: string) => {
+  // ⚡ Bolt: Memoize handler to prevent unnecessary re-renders of heavy child components
+  const handleWallpaperChange = useCallback((newWallpaper: string) => {
     console.log('New wallpaper:', newWallpaper); // Debug log
     setWallpaper(newWallpaper);
-  };
+  }, []);
 
   // Add this style to your main container
   const backgroundStyle = wallpaper


### PR DESCRIPTION
💡 What: Optimized heavy UI components containing `framer-motion` hooks (`FloatingDock`, `DesktopIcons`, `Quote`) by wrapping them in `React.memo` and strictly memoizing their props (`useCallback`, `useMemo`).
🎯 Why: `framer-motion` hooks (`useSpring`, `useTransform`) are computationally expensive. When the parent `Home` component state changes (e.g., toggling `isCLI` or updating `wallpaper`), it triggered full re-renders of the unmemoized UI elements and re-evaluated the framer-motion hooks, causing layout thrashing and garbage collection overhead.
📊 Impact: Prevents full DOM tree re-renders of the application's most expensive components when unrelated state changes occur in the main `Home` layout.
🔬 Measurement: Run a React profiler and toggle the `wallpaper` state; the child components (`DesktopIcons`, `FloatingDockDemo`, etc.) will no longer re-render.

---
*PR created automatically by Jules for task [16076488344097388802](https://jules.google.com/task/16076488344097388802) started by @Pranav322*