### PR TITLE
⚡ Bolt: prevent cascading re-renders of heavy UI components

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-03-07 - [React Render Optimization with Memoization]
+**Learning:** In heavy Next.js applications, passing inline arrays containing JSX/functions (e.g., `links` array in `Navbar`) or unmemoized callbacks (e.g., `handleWallpaperChange`) to heavy child components like `DesktopIcons` or `FloatingDock` breaks `React.memo` by changing referential equality on every parent re-render.
+**Action:** Always wrap heavy, pure components with `React.memo` (using named function expressions to satisfy ESLint) and ensure all props passed to them are strictly referentially stable by using `useMemo` for objects/arrays and `useCallback` for functions.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -28,7 +28,7 @@ interface FloatingDockDemoProps {
   onWallpaperChange: (wallpaper: string) => void;
 }
 
-function FloatingDockDemo({
+const FloatingDockDemo = React.memo(function FloatingDockDemo({
   desktopClassName,
   mobileClassName,
   onWallpaperChange,
@@ -36,7 +36,9 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
+  // Memoize links array to prevent unnecessary recreation on re-renders,
+  // especially since it contains JSX and inline functions.
+  const links = useMemo(() => [
     {
       title: 'Home',
       icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
@@ -74,7 +76,7 @@ function FloatingDockDemo({
       icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: 'https://github.com/pranav322',
     },
-  ];
+  ], []);
 
   return (
     <>
@@ -93,6 +95,6 @@ function FloatingDockDemo({
       {showGames && <GamesWindow onClose={() => setShowGames(false)} />}
     </>
   );
-}
+});
 
 export default FloatingDockDemo;

--- a/app/components/ui/DesktopIcons.tsx
+++ b/app/components/ui/DesktopIcons.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { AnimatePresence } from 'framer-motion';
 
 // Hook to detect device types
@@ -149,7 +149,7 @@ const handlePrefetch = (iconName: string) => {
 };
 import { useTheme } from '../../contexts/ThemeContext';
 
-export function DesktopIcons({
+export const DesktopIcons = React.memo(function DesktopIcons({
   onWallpaperChange,
 }: {
   onWallpaperChange?: (wallpaper: string) => void;
@@ -548,4 +548,4 @@ export function DesktopIcons({
       {showPranavChat && <PranavChatWindow onClose={() => setShowPranavChat(false)} />}
     </>
   );
-}
+});

--- a/app/components/ui/Quote.tsx
+++ b/app/components/ui/Quote.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
 import { motion } from 'framer-motion';
 
-export function Quote() {
+export const Quote = React.memo(function Quote() {
   return (
     <motion.div
       initial={{ opacity: 0, y: -20 }}
@@ -13,4 +14,4 @@ export function Quote() {
       <p className="text-white/40 text-xs text-right">— Charles Bukowski</p>
     </motion.div>
   );
-}
+});

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 interface DockItem {
   title: string;
@@ -151,7 +151,7 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+const IconContainer = React.memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +278,4 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { ToggleButton } from './components/ui/ButtonToggle';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import FloatingDockDemo from './components/Navbar';
 import { DesktopIcons } from './components/ui/DesktopIcons';
 import { Quote } from './components/ui/Quote';
@@ -20,10 +20,11 @@ export default function Home() {
   const [isCLI, setIsCLI] = useState(false);
   const [wallpaper, setWallpaper] = useState<string | null>(null);
 
-  const handleWallpaperChange = (newWallpaper: string) => {
+  // Memoize handler to prevent unnecessary re-renders of heavy child components (DesktopIcons, FloatingDockDemo)
+  const handleWallpaperChange = useCallback((newWallpaper: string) => {
     console.log('New wallpaper:', newWallpaper); // Debug log
     setWallpaper(newWallpaper);
-  };
+  }, []);
 
   // Add this style to your main container
   const backgroundStyle = wallpaper


### PR DESCRIPTION
💡 What: Wrapped `FloatingDockDemo`, `DesktopIcons`, `Quote`, and `IconContainer` in `React.memo`. Memoized `handleWallpaperChange` (via `useCallback`) and the `links` array (via `useMemo`) to maintain referential stability.

🎯 Why: The root `Home` component updates state on actions like changing the wallpaper or toggling CLI mode. Without memoization, this triggered a complete cascading re-render of massive, heavy components like `DesktopIcons` and `FloatingDock` which internally execute heavy Framer Motion hooks.

📊 Impact: Massively reduces unnecessary virtual DOM diffing and execution of expensive hooks (`useSpring`, `useTransform`) during root state updates.

🔬 Measurement: Verify by toggling wallpaper settings or changing state in the main page; React DevTools profiler will show the child components effectively skipping renders.

---
*PR created automatically by Jules for task [14540349760783702449](https://jules.google.com/task/14540349760783702449) started by @Pranav322*