### PR TITLE
🎨 Palette: Add accessibility labels to all Window controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Accessibility for Reusable Window Controls
+**Learning:** Reusable OS-style window UI elements (like Minimize, Maximize, Close icons) across various window components (e.g., SpotifyWindow, BrowserWindow) often lack semantic context, making them completely inaccessible to screen reader users and ambiguous to keyboard users without hover.
+**Action:** Always include both `aria-label` (for screen readers) and `title` (for mouse hover tooltips) on all icon-only window control buttons across the application to ensure consistent, accessible context regardless of input method.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -50,6 +50,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -57,13 +59,17 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -133,6 +133,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -140,13 +142,17 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -80,6 +80,8 @@ export function BrowserWindow({
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -87,13 +89,17 @@ export function BrowserWindow({
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -74,6 +74,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -81,13 +83,17 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -50,6 +50,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
               onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -57,13 +59,17 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -40,6 +40,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -47,13 +49,17 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -128,6 +128,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -135,13 +137,17 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -45,6 +45,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -52,13 +54,17 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -313,6 +313,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -320,13 +322,17 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -54,6 +54,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -61,13 +63,17 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
-            >
+
+              aria-label="Maximize"
+              title="Maximize">
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -42,16 +42,25 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
             <button
               onClick={handleMinimize}
               className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={18} />
             </button>
             <button
               onClick={toggleMaximize}
               className="text-white/50 hover:text-white transition-colors"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              onClick={onClose}
+              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Close"
+              title="Close"
+            >
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the Minimize, Maximize, and Close control buttons across all Window components.
🎯 Why: These buttons were completely icon-only (`<IconMinus>`, `<IconSquare>`, `<IconX>`), which provides no semantic context for screen readers and no visual feedback for keyboard/mouse users upon hover, degrading overall accessibility and usability.
📸 Before/After: Visual tooltips "Minimize", "Maximize", and "Close" now appear when hovered. Screen readers will now announce "Minimize button", "Maximize button", and "Close button" instead of generic non-descriptive elements.
♿ Accessibility: Increased a11y support for screen reader users and improved context for mouse hover.

---
*PR created automatically by Jules for task [4288458941071083550](https://jules.google.com/task/4288458941071083550) started by @Pranav322*