### PR TITLE
⚡ Bolt: Prevent expensive Framer Motion hook recalculations in FloatingDock

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-13 - [Framer Motion Hooks & Array Memoization]
+**Learning:** Components containing expensive Framer Motion hooks (like `useSpring`, `useTransform`, e.g., `IconContainer`) will experience severe performance degradation if they re-render frequently. Furthermore, arrays containing JSX elements or functions passed as props to such components will always break referential equality unless explicitly memoized.
+**Action:** Always wrap components using expensive Framer Motion calculations in `React.memo`. Crucially, ensure any object arrays with JSX/functions passed to them are memoized via `useMemo` at the parent level, or the component memoization will be defeated.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -36,7 +36,8 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
+  // ⚡ Bolt: Memoize links array to prevent re-renders in child components
+  const links = useMemo(() => [
     {
       title: 'Home',
       icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
@@ -74,7 +75,7 @@ function FloatingDockDemo({
       icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: 'https://github.com/pranav322',
     },
-  ];
+  ], [setShowSettings, setShowGames]);
 
   return (
     <>

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, memo } from 'react';
 
 interface DockItem {
   title: string;
@@ -151,7 +151,8 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+// ⚡ Bolt: Memoize IconContainer to prevent expensive Framer Motion hook recalculations on parent re-render
+const IconContainer = memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +279,6 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});
+
+IconContainer.displayName = 'IconContainer';


### PR DESCRIPTION
💡 What: 
Wrapped the `IconContainer` in `React.memo` and the `links` array in `app/components/Navbar.tsx` with `useMemo`.

🎯 Why: 
The `FloatingDock` implementation was passing a non-memoized array (containing complex JSX items and functions) into the `IconContainer` components. When the parent re-renders, the `IconContainer` (which uses expensive `framer-motion` hooks like `useSpring` and `useTransform`) was unnecessarily re-rendering, causing performance degradation, especially evident in physics-based, mouse-driven animations like a fisheye dock.

📊 Impact: 
Significantly reduces React re-renders for the `FloatingDock` component. Previously, any parent re-render would force recalculation of the heavy physics hooks for every single dock item. By ensuring referential equality of the props and memoizing the component, we skip these heavy updates completely unless the specific dock item data changes.

🔬 Measurement: 
Can be verified using React DevTools Profiler by interacting with the parent components (like opening/closing windows that share state with the navbar) and observing that `IconContainer` instances now bail out of rendering.

---
*PR created automatically by Jules for task [17674397379490421627](https://jules.google.com/task/17674397379490421627) started by @Pranav322*