### PR TITLE
🎨 Palette: Add accessibility attributes to window control buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-03-14 - Duplicated Window Controls
+**Learning:** Repetitive UI components that are duplicated across multiple files (like window controls for Minimize/Maximize/Close) are prone to missing accessibility attributes. Since they use icon-only buttons, omitting both `aria-label` (for screen readers) and `title` (for tooltips) causes a significant UX gap for multiple user types.
+**Action:** Always ensure that both `aria-label` and `title` attributes are included on icon-only buttons that provide core application functionality, especially when these controls are manually duplicated across similar components rather than abstracted into a shared UI component.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -47,7 +47,7 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           </div>
           {/* Window Controls */}
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
@@ -60,7 +60,7 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -130,7 +130,7 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             <span className="text-white/90 text-sm font-medium">Books</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
@@ -143,7 +143,7 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -77,7 +77,7 @@ export function BrowserWindow({
             <span className="text-white/90 text-sm font-medium">Browser</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
@@ -90,7 +90,7 @@ export function BrowserWindow({
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -70,7 +70,7 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
           </div>
           {/* Window Controls */}
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
@@ -84,7 +84,7 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -46,7 +46,7 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             <span className="text-white/90 text-sm font-medium">Games</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
               onClick={handleMinimize}
@@ -60,7 +60,7 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -37,7 +37,7 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             <span className="text-white/90 text-sm font-medium">Resume.pdf</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
@@ -50,7 +50,7 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -125,7 +125,7 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             <span className="text-white/90 text-sm font-medium">Pranav AI</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
@@ -138,7 +138,7 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -42,7 +42,7 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             <span className="text-white/90 text-sm font-medium">Projects</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
@@ -55,7 +55,7 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -309,7 +309,7 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             <span className="text-white/90 text-sm font-medium">Settings</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
@@ -323,7 +323,7 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -51,7 +51,7 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             <span className="text-white/90 text-sm font-medium">Skills</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
@@ -64,7 +64,7 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -39,19 +39,19 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
             <span className="text-white/90 text-sm font-medium">Spotify Stats</span>
           </div>
           <div className="flex items-center gap-4">
-            <button
+            <button aria-label="Minimize" title="Minimize"
               onClick={handleMinimize}
               className="text-white/50 hover:text-white transition-colors"
             >
               <IconMinus size={18} />
             </button>
-            <button
+            <button aria-label="Maximize" title="Maximize"
               onClick={toggleMaximize}
               className="text-white/50 hover:text-white transition-colors"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button aria-label="Close" title="Close" onClick={onClose} className="text-white/50 hover:text-white transition-colors">
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the Minimize, Maximize, and Close icon-only buttons across various `*Window.tsx` components.
🎯 Why: Without these labels, screen reader users cannot identify what the window control buttons do, and mouse users lack helpful hover tooltips. This enhances the accessibility and general usability of the window-based UI.
♿ Accessibility: Provides explicit naming for assistive technologies and standard visual tooltips for pointing devices.

---
*PR created automatically by Jules for task [6571330123496326104](https://jules.google.com/task/6571330123496326104) started by @Pranav322*