### PR TITLE
⚡ Bolt: Memoize FloatingDock items to prevent expensive Framer Motion recalculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Memoizing Expensive Framer Motion Hooks
+**Learning:** Components containing Framer Motion hooks like `useSpring` and `useTransform` are expensive to recalculate on every render. Parent re-renders can trigger these calculations unnecessarily if not properly handled, severely degrading performance during animations or interactions.
+**Action:** When using Framer Motion hooks inside a child component (like `IconContainer` in `FloatingDock`), ALWAYS wrap the child component in `React.memo()`. Additionally, ensure that the parent component passes stable props (memoizing arrays/objects with `useMemo` and functions with `useCallback`) to preserve referential equality and successfully skip the child's re-render.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -36,7 +36,14 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
+  // Memoize actions to prevent recreating functions on every render
+  const openSettings = useCallback(() => setShowSettings(true), []);
+  const openGames = useCallback(() => setShowGames(true), []);
+  const closeSettings = useCallback(() => setShowSettings(false), []);
+  const closeGames = useCallback(() => setShowGames(false), []);
+
+  // Memoize links array so FloatingDock doesn't re-render its expensive children
+  const links = useMemo(() => [
     {
       title: 'Home',
       icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
@@ -46,13 +53,8 @@ function FloatingDockDemo({
       title: 'Settings',
       icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: '#',
-      action: () => setShowSettings(true),
+      action: openSettings,
     },
-    // {
-    //   title: 'Components',
-    //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-    //   href: '#',
-    // },
     {
       title: 'Games',
       icon: (
@@ -62,7 +64,7 @@ function FloatingDockDemo({
         />
       ),
       href: '#',
-      action: () => setShowGames(true),
+      action: openGames,
     },
     {
       title: 'Twitter',
@@ -74,7 +76,7 @@ function FloatingDockDemo({
       icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: 'https://github.com/pranav322',
     },
-  ];
+  ], [openSettings, openGames]);
 
   return (
     <>
@@ -86,11 +88,11 @@ function FloatingDockDemo({
 
       {showSettings && (
         <SettingsWindow
-          onClose={() => setShowSettings(false)}
+          onClose={closeSettings}
           onWallpaperChange={onWallpaperChange}
         />
       )}
-      {showGames && <GamesWindow onClose={() => setShowGames(false)} />}
+      {showGames && <GamesWindow onClose={closeGames} />}
     </>
   );
 }

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 interface DockItem {
   title: string;
@@ -151,7 +151,7 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+const IconContainer = React.memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +278,5 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});
+IconContainer.displayName = 'IconContainer';


### PR DESCRIPTION
💡 **What:** 
- Wrapped the `IconContainer` component in `app/components/ui/floating-dock.tsx` with `React.memo()`.
- Memoized the `links` array using `useMemo` and the action callbacks (`setShowSettings`, `setShowGames`) using `useCallback` inside `app/components/Navbar.tsx`.
- Documented this critical performance pattern in `.jules/bolt.md`.

🎯 **Why:** 
The `FloatingDock` component is composed of multiple `IconContainer` children. Each of these children relies heavily on Framer Motion hooks (`useSpring`, `useTransform`) to calculate distance and scale based on mouse position. By default, whenever the parent (`Navbar.tsx`) re-rendered—such as when opening the Settings or Games window—all of these expensive hooks across all icons were forced to recalculate needlessly. 

By applying `React.memo()` to the child and providing stable props from the parent, we successfully break this render chain, ensuring the `IconContainer`s only update when they actually need to (e.g., when hovered or focused).

📊 **Impact:** 
Eliminates unnecessary re-renders of all `IconContainer` components (and their internal `useSpring`/`useTransform` calculations) whenever the user opens or closes a window launched from the dock. This results in smoother animations and less main-thread blocking during interactions.

🔬 **Measurement:** 
Run `pnpm dev`, open React DevTools, enable "Highlight updates when components render", and click on the "Settings" or "Games" icon in the dock. Previously, the entire dock would flash indicating a re-render. With this optimization, only the parent and the newly opened window will render. Verify with `pnpm lint` and `pnpm exec tsc --noEmit`.

---
*PR created automatically by Jules for task [15183699061705891183](https://jules.google.com/task/15183699061705891183) started by @Pranav322*