### PR TITLE
🎨 Palette: Add accessibility attributes to window controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Accessibility of Icon-Only Window Controls
+**Learning:** Icon-only window controls (Minimize, Maximize, Close) lack context for screen readers and keyboard users who cannot easily discover their purpose without tooltips or labels. Providing both \`aria-label\` and native \`title\` attributes solves this for both user bases.
+**Action:** Always add \`aria-label\` and \`title\` to icon-only buttons like window controls to ensure they are accessible to screen readers and provide hover tooltips for visual users. When mass-updating with regex, account for arrow functions in event handlers.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -47,20 +47,20 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           </div>
           {/* Window Controls */}
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -130,20 +130,20 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             <span className="text-white/90 text-sm font-medium">Books</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -77,20 +77,20 @@ export function BrowserWindow({
             <span className="text-white/90 text-sm font-medium">Browser</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -70,21 +70,21 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
           </div>
           {/* Window Controls */}
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -46,21 +46,21 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             <span className="text-white/90 text-sm font-medium">Games</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
               onClick={handleMinimize}
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -37,20 +37,20 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             <span className="text-white/90 text-sm font-medium">Resume.pdf</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -125,20 +125,20 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             <span className="text-white/90 text-sm font-medium">Pranav AI</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -42,20 +42,20 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             <span className="text-white/90 text-sm font-medium">Projects</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -309,21 +309,21 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             <span className="text-white/90 text-sm font-medium">Settings</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -51,20 +51,20 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             <span className="text-white/90 text-sm font-medium">Skills</span>
           </div>
           <div className="flex items-center gap-1">
-            <motion.button
+            <motion.button aria-label="Minimize" title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Maximize" title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
-            <motion.button
+            <motion.button aria-label="Close" title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -39,19 +39,19 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
             <span className="text-white/90 text-sm font-medium">Spotify Stats</span>
           </div>
           <div className="flex items-center gap-4">
-            <button
+            <button aria-label="Minimize" title="Minimize"
               onClick={handleMinimize}
               className="text-white/50 hover:text-white transition-colors"
             >
               <IconMinus size={18} />
             </button>
-            <button
+            <button aria-label="Maximize" title="Maximize"
               onClick={toggleMaximize}
               className="text-white/50 hover:text-white transition-colors"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button aria-label="Close" title="Close" onClick={onClose} className="text-white/50 hover:text-white transition-colors">
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-label` and native `title` attributes to the window control buttons (Minimize, Maximize, Close) across all 11 window components in `app/components/windows/`.
🎯 Why: These buttons were completely icon-only (`<IconMinus />`, `<IconSquare />`, `<IconX />`), making them inaccessible to screen readers. Furthermore, keyboard and mouse users relying on tooltips to discover their purpose were left guessing.
📸 Before/After: Screenshots were taken in the playwright verification phase. Tooltips now appear natively on hover.
♿ Accessibility: Improves WCAG compliance for `Name, Role, Value` (4.1.2) and `Non-text Content` (1.1.1) by ensuring interactive icon-only elements have an accessible name.

---
*PR created automatically by Jules for task [15820872086990637577](https://jules.google.com/task/15820872086990637577) started by @Pranav322*