### PR TITLE
⚡ Bolt: Memoize FloatingDock links array to prevent unnecessary re-renders

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-13 - [Memoization of Arrays Passed to Framer Motion Components]
+**Learning:** Arrays defined inside a component body without memoization are recreated on every render. If these arrays are passed down to child components that use heavy computation or hooks like Framer Motion's `useSpring` and `useTransform` (e.g., `IconContainer` in `floating-dock.tsx`), it causes unnecessary and expensive re-renders across all those children when the parent updates (e.g., from simple state changes like opening a modal).
+**Action:** For completely static data, move the array/object definition completely outside the component scope to avoid hook overhead. If the data requires component scope (e.g., uses state setters in callbacks), wrap it in `React.useMemo` to ensure referential equality and prevent performance degradation in heavy child components.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -36,7 +36,14 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
+  // ⚡ Bolt: Provide a stable reference to the links array to maintain referential equality across renders.
+  // The FloatingDock component passes these items to IconContainer components which
+  // use heavy Framer Motion hooks (useSpring, useTransform). Recreating this array
+  // on every parent render (like when showSettings/showGames state changes) causes
+  // unnecessary and expensive re-renders of all dock icons.
+  // Using useMemo since some items (Settings/Games) contain actions that reference state setters
+  // that need access to the component scope.
+  const links = React.useMemo(() => [
     {
       title: 'Home',
       icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
@@ -74,7 +81,7 @@ function FloatingDockDemo({
       icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: 'https://github.com/pranav322',
     },
-  ];
+  ], [setShowSettings, setShowGames]);
 
   return (
     <>


### PR DESCRIPTION
💡 What: Memoized the `links` array inside `FloatingDockDemo` in `Navbar.tsx` using `React.useMemo`.

🎯 Why: The `links` array is passed down through `FloatingDock` and mapped into `IconContainer` components. Each `IconContainer` uses expensive Framer Motion calculations and hooks (`useSpring`, `useTransform`). Without memoization, `links` was recreated on every state change in `FloatingDockDemo` (such as opening settings or games), causing all dock items to unnecessarily re-render and re-initialize their motion logic. `React.useMemo` is used instead of moving the array outside the component because the links rely on closures over the `setShowSettings` and `setShowGames` state setters.

📊 Impact: Significantly reduces component re-renders of the floating dock when interacting with UI elements in `FloatingDockDemo`, preventing performance hits from unneeded Framer Motion recalcs.

🔬 Measurement: Profile the application when clicking on the `Settings` or `Games` dock icons; the `IconContainer`s will no longer re-render unnecessarily when the modals open/close.

---
*PR created automatically by Jules for task [66540778290844781](https://jules.google.com/task/66540778290844781) started by @Pranav322*