### PR TITLE
⚡ Bolt: Memoize FloatingDock items to prevent expensive Framer Motion re-renders

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-13 - [Framer Motion Hooks & React.memo]
+**Learning:** Components using expensive Framer Motion hooks (e.g., `useSpring`, `useTransform` in `IconContainer`) are highly susceptible to performance degradation if parent state changes cause unnecessary re-renders. Simply passing stable setter functions is not enough if inline arrays or objects are recreated on every render.
+**Action:** Always wrap components containing expensive Framer Motion calculations in `React.memo()`. Additionally, ensure all props passed to them (like arrays or callbacks) from the parent are properly memoized with `useMemo` or `useCallback` to maintain referential equality and prevent the memoized child from re-rendering.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -36,45 +36,50 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
-    {
-      title: 'Home',
-      icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: '#',
-    },
-    {
-      title: 'Settings',
-      icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: '#',
-      action: () => setShowSettings(true),
-    },
-    // {
-    //   title: 'Components',
-    //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-    //   href: '#',
-    // },
-    {
-      title: 'Games',
-      icon: (
-        <IconDeviceGamepad2
-          size={24}
-          className="h-full w-full text-neutral-500 dark:text-neutral-300"
-        />
-      ),
-      href: '#',
-      action: () => setShowGames(true),
-    },
-    {
-      title: 'Twitter',
-      icon: <IconBrandX className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: 'https://x.com/_pranav69',
-    },
-    {
-      title: 'GitHub',
-      icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: 'https://github.com/pranav322',
-    },
-  ];
+  // ⚡ Bolt Optimization: Memoize the links array to prevent unnecessary re-renders of the
+  // FloatingDockDesktop component and its expensive IconContainer children when parent state changes.
+  const links = useMemo(
+    () => [
+      {
+        title: 'Home',
+        icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: '#',
+      },
+      {
+        title: 'Settings',
+        icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: '#',
+        action: () => setShowSettings(true),
+      },
+      // {
+      //   title: 'Components',
+      //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+      //   href: '#',
+      // },
+      {
+        title: 'Games',
+        icon: (
+          <IconDeviceGamepad2
+            size={24}
+            className="h-full w-full text-neutral-500 dark:text-neutral-300"
+          />
+        ),
+        href: '#',
+        action: () => setShowGames(true),
+      },
+      {
+        title: 'Twitter',
+        icon: <IconBrandX className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: 'https://x.com/_pranav69',
+      },
+      {
+        title: 'GitHub',
+        icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: 'https://github.com/pranav322',
+      },
+    ],
+    []
+  );
 
   return (
     <>

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 interface DockItem {
   title: string;
@@ -151,7 +151,9 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+// ⚡ Bolt Optimization: Wrap IconContainer in React.memo to prevent expensive
+// Framer Motion hook recalculations (useSpring, useTransform) when parent components re-render.
+const IconContainer = React.memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +280,5 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});
+IconContainer.displayName = 'IconContainer';


### PR DESCRIPTION
💡 What: Wrapped `IconContainer` in `React.memo` and memoized the `links` array passed from `Navbar` using `useMemo`.
🎯 Why: `IconContainer` uses expensive Framer Motion calculations (`useSpring`, `useTransform`). Without memoization, any unrelated state change in the parent `FloatingDockDemo` (like toggling settings or games) caused the `links` array to be recreated, forcing the entire `FloatingDockDesktop` and all its `IconContainer` children to re-render needlessly.
📊 Impact: Reduces unnecessary re-renders of the floating dock icons to exactly zero when opening/closing unrelated UI panels.
🔬 Measurement: Verify by adding a `console.log` inside `IconContainer` and toggling the Settings window. Before: logs on every toggle. After: only logs on initial render.

---
*PR created automatically by Jules for task [6366928650022679123](https://jules.google.com/task/6366928650022679123) started by @Pranav322*