### PR TITLE
⚡ Bolt: Memoize FloatingDock components and props

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2026-03-23 - [Memoizing Framer Motion Components vs Props]
+**Learning:** Wrapping complex inner Framer Motion components (like those relying on useSpring/useTransform) in `React.memo` is often redundant and adds boilerplate if the parent component is already memoized and its props (like arrays) are stabilized with `useMemo`. React Next.js app crashed potential avoided by ensuring `React` import is present when using hooks implicitly.
+**Action:** Prioritize memoizing the expensive props at the source (using `useMemo` for configuration arrays like `links`) and the top-level parent component, rather than indiscriminately applying `React.memo` to all child components, which increases complexity with minimal gain.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -36,7 +36,7 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
+  const links = React.useMemo(() => [
     {
       title: 'Home',
       icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
@@ -74,7 +74,7 @@ function FloatingDockDemo({
       icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
       href: 'https://github.com/pranav322',
     },
-  ];
+  ], []);
 
   return (
     <>

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 interface DockItem {
   title: string;
@@ -24,7 +24,7 @@ interface DockItem {
   action?: () => void;
 }
 
-export const FloatingDock = ({
+export const FloatingDock = React.memo(({
   items,
   desktopClassName,
   mobileClassName,
@@ -39,7 +39,8 @@ export const FloatingDock = ({
       <FloatingDockMobile items={items} className={mobileClassName} />
     </>
   );
-};
+});
+FloatingDock.displayName = 'FloatingDock';
 
 const FloatingDockMobile = ({ items, className }: { items: DockItem[]; className?: string }) => {
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
💡 What: Memoize the `links` prop using `React.useMemo` and wrap the `FloatingDock` component with `React.memo` to prevent redundant computations.
🎯 Why: In `Navbar.tsx`, the `links` array is recreated on every render of the `FloatingDockDemo` component (e.g., when the `showSettings` state changes). This causes the `FloatingDock` component, which utilizes expensive `framer-motion` hooks (`useSpring`, `useTransform`), to re-render needlessly.
📊 Impact: Reduces unnecessary re-renders of the dock and its inner `IconContainer`s when other parts of the desktop layout state are modified.
🔬 Measurement: Can be verified using React DevTools Profiler to ensure `FloatingDock` and its children do not re-render when an external state update like `setShowSettings` is triggered.

---
*PR created automatically by Jules for task [5000120422907790839](https://jules.google.com/task/5000120422907790839) started by @Pranav322*