### PR TITLE
⚡ Bolt: Memoize Dock links and IconContainer to prevent unnecessary re-renders

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2026-03-24 - [Framer Motion and React.memo()]
+**Learning:** Components using expensive Framer Motion hooks (`useSpring`, `useTransform`) combined with static array props in Next.js cause performance degradation from parent re-renders. When the parent (e.g., `Navbar`) recreates its configuration array (e.g., `links`) on state change, the child un-memoized components using Framer hooks recalculate everything.
+**Action:** Always wrap components containing heavy animation hooks in `React.memo()` and memoize their props (arrays, functions) at the parent level using `useMemo` or `useCallback` to preserve referential equality and prevent cascading re-renders.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -36,45 +36,48 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
-    {
-      title: 'Home',
-      icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: '#',
-    },
-    {
-      title: 'Settings',
-      icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: '#',
-      action: () => setShowSettings(true),
-    },
-    // {
-    //   title: 'Components',
-    //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-    //   href: '#',
-    // },
-    {
-      title: 'Games',
-      icon: (
-        <IconDeviceGamepad2
-          size={24}
-          className="h-full w-full text-neutral-500 dark:text-neutral-300"
-        />
-      ),
-      href: '#',
-      action: () => setShowGames(true),
-    },
-    {
-      title: 'Twitter',
-      icon: <IconBrandX className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: 'https://x.com/_pranav69',
-    },
-    {
-      title: 'GitHub',
-      icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: 'https://github.com/pranav322',
-    },
-  ];
+  const links = useMemo(
+    () => [
+      {
+        title: 'Home',
+        icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: '#',
+      },
+      {
+        title: 'Settings',
+        icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: '#',
+        action: () => setShowSettings(true),
+      },
+      // {
+      //   title: 'Components',
+      //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+      //   href: '#',
+      // },
+      {
+        title: 'Games',
+        icon: (
+          <IconDeviceGamepad2
+            size={24}
+            className="h-full w-full text-neutral-500 dark:text-neutral-300"
+          />
+        ),
+        href: '#',
+        action: () => setShowGames(true),
+      },
+      {
+        title: 'Twitter',
+        icon: <IconBrandX className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: 'https://x.com/_pranav69',
+      },
+      {
+        title: 'GitHub',
+        icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: 'https://github.com/pranav322',
+      },
+    ],
+    []
+  );
 
   return (
     <>

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 interface DockItem {
   title: string;
@@ -151,7 +151,7 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+const IconContainer = React.memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +278,6 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});
+
+IconContainer.displayName = 'IconContainer';


### PR DESCRIPTION
💡 **What**:
- Memoized the `links` array in `Navbar.tsx` using `useMemo()`.
- Wrapped `IconContainer` in `floating-dock.tsx` with `React.memo()`.

🎯 **Why**:
- The `links` array was being recreated on every render of `FloatingDockDemo` (such as when toggling `showSettings` or `showGames`). 
- Because `IconContainer` relies on heavy `framer-motion` hooks (`useSpring`, `useTransform`), passing a newly recreated array of objects caused all icons to re-render, recalculating expensive animation states unnecessarily. 

📊 **Impact**:
- Prevents cascading re-renders of dock icons when interacting with dock items that trigger local state changes (e.g., opening the settings window). Reduces CPU overhead and maintains smoother animations.

🔬 **Measurement**:
- Before: Clicking "Settings" triggers a re-render of `FloatingDockDemo`, which re-renders all 5 `IconContainer` components.
- After: Clicking "Settings" triggers a re-render of `FloatingDockDemo`, but `IconContainer` components skip rendering due to `React.memo` and stable `links` references.

---
*PR created automatically by Jules for task [887489667407567128](https://jules.google.com/task/887489667407567128) started by @Pranav322*