### PR TITLE
⚡ Bolt: Memoize expensive floating dock icons

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2026-03-25 - [Memoizing Expensive Framer Motion Hooks]
+
+**Learning:** Components using expensive Framer Motion hooks (e.g., `useSpring`, `useTransform`) must be wrapped in `React.memo` to prevent performance degradation from parent re-renders. Additionally, all props passed to them (like arrays or callbacks) must be properly memoized with `useMemo` or `useCallback` at the parent level to maintain referential equality.
+**Action:** Always verify if components rendering heavy hooks are protected against unnecessary re-renders. If a parent passes an inline array or object, memoize it.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FloatingDock } from './ui/floating-dock';
 import {
   IconBrandGithub,
@@ -36,45 +36,49 @@ function FloatingDockDemo({
   const [showSettings, setShowSettings] = useState(false);
   const [showGames, setShowGames] = useState(false);
 
-  const links = [
-    {
-      title: 'Home',
-      icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: '#',
-    },
-    {
-      title: 'Settings',
-      icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: '#',
-      action: () => setShowSettings(true),
-    },
-    // {
-    //   title: 'Components',
-    //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-    //   href: '#',
-    // },
-    {
-      title: 'Games',
-      icon: (
-        <IconDeviceGamepad2
-          size={24}
-          className="h-full w-full text-neutral-500 dark:text-neutral-300"
-        />
-      ),
-      href: '#',
-      action: () => setShowGames(true),
-    },
-    {
-      title: 'Twitter',
-      icon: <IconBrandX className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: 'https://x.com/_pranav69',
-    },
-    {
-      title: 'GitHub',
-      icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
-      href: 'https://github.com/pranav322',
-    },
-  ];
+  // Memoize links to prevent expensive Framer Motion hook recalculations in children
+  const links = useMemo(
+    () => [
+      {
+        title: 'Home',
+        icon: <IconHome className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: '#',
+      },
+      {
+        title: 'Settings',
+        icon: <IconSettings className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: '#',
+        action: () => setShowSettings(true),
+      },
+      // {
+      //   title: 'Components',
+      //   icon: <IconNewSection className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+      //   href: '#',
+      // },
+      {
+        title: 'Games',
+        icon: (
+          <IconDeviceGamepad2
+            size={24}
+            className="h-full w-full text-neutral-500 dark:text-neutral-300"
+          />
+        ),
+        href: '#',
+        action: () => setShowGames(true),
+      },
+      {
+        title: 'Twitter',
+        icon: <IconBrandX className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: 'https://x.com/_pranav69',
+      },
+      {
+        title: 'GitHub',
+        icon: <IconBrandGithub className="h-full w-full text-neutral-500 dark:text-neutral-300" />,
+        href: 'https://github.com/pranav322',
+      },
+    ],
+    []
+  );
 
   return (
     <>

--- a/app/components/ui/floating-dock.tsx
+++ b/app/components/ui/floating-dock.tsx
@@ -15,7 +15,7 @@ import {
   useTransform,
 } from 'framer-motion';
 import Link from 'next/link';
-import { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 interface DockItem {
   title: string;
@@ -151,7 +151,7 @@ const FloatingDockDesktop = ({ items, className }: { items: DockItem[]; classNam
   );
 };
 
-function IconContainer({
+const IconContainer = React.memo(function IconContainer({
   mouseX,
   title,
   icon,
@@ -278,4 +278,6 @@ function IconContainer({
       {content}
     </button>
   );
-}
+});
+
+IconContainer.displayName = 'IconContainer';


### PR DESCRIPTION
### 💡 What:
Wrapped the `IconContainer` component in `React.memo` and memoized the `links` array passed down from `app/components/Navbar.tsx` using `useMemo`.

### 🎯 Why:
The `Navbar` component holds states for displaying various windows (`showSettings`, `showGames`). Whenever these windows are toggled, the entire `Navbar` re-renders, generating a new `links` array, which in turn causes all instances of `IconContainer` to re-render. Since `IconContainer` uses expensive Framer Motion hooks like `useSpring` and `useTransform`, these unnecessary re-renders are computationally heavy. Memoization prevents them.

### 📊 Impact:
Reduces expensive `useSpring`/`useTransform` re-evaluations inside the Dock to exactly `0` when simply toggling windows (like Settings or Games) or other unrelated state changes in `Navbar.tsx`.

### 🔬 Measurement:
Start the app and use React DevTools Profiler to record interactions when toggling the "Settings" or "Games" window. The `IconContainer` components will now be greyed out (memoized/skipped) instead of rendering. Alternatively, dropping a `console.log` inside `IconContainer` will show that it no longer triggers on state changes within `Navbar`.

---
*PR created automatically by Jules for task [3315965759607499270](https://jules.google.com/task/3315965759607499270) started by @Pranav322*