### PR TITLE
🎨 Palette: Improve Window Control Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,10 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Window Controls Accessibility
+**Learning:** Icon-only window controls (Minimize, Maximize, Close) lack context for screen readers and sighted users.
+**Action:** Always add explicit `aria-label` (for screen readers) and `title` attributes (for mouse hover tooltips) directly within each respective window control component file to maintain accessibility.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -50,6 +50,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -57,6 +59,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -64,6 +68,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -133,6 +133,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -140,6 +142,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -147,6 +151,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -80,6 +80,8 @@ export function BrowserWindow({
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -87,6 +89,8 @@ export function BrowserWindow({
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -94,6 +98,8 @@ export function BrowserWindow({
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -74,6 +74,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -81,6 +83,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -88,6 +92,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -50,6 +50,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
               onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -57,6 +59,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -64,6 +68,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -40,6 +40,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -47,6 +49,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -54,6 +58,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -128,6 +128,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -135,6 +137,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -142,6 +146,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -45,6 +45,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -52,6 +54,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -59,6 +63,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -313,6 +313,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -320,6 +322,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -327,6 +331,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -54,6 +54,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -61,6 +63,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -68,6 +72,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -42,16 +42,25 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
             <button
               onClick={handleMinimize}
               className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={18} />
             </button>
             <button
               onClick={toggleMaximize}
               className="text-white/50 hover:text-white transition-colors"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              onClick={onClose}
+              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Close"
+              title="Close"
+            >
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
🎨 **Palette: Window Controls Accessibility Improvement**

💡 **What:** Added `aria-label` and `title` attributes to all window control buttons (Minimize, Maximize, Close) within `app/components/windows/`.
🎯 **Why:** Icon-only buttons lack context for both screen reader users and sighted mouse users (who benefit from hover tooltips). Providing explicit labels bridges this gap and ensures a more accessible, intuitive desktop-like experience.
♿ **Accessibility:** Screen readers can now correctly identify the actions of these window controls instead of reading generic, unlabeled button groups.

---
*PR created automatically by Jules for task [13141232084065932719](https://jules.google.com/task/13141232084065932719) started by @Pranav322*