### PR TITLE
🎨 Palette: Add ARIA labels and native tooltips to window controls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Window Controls ARIA Labels and Native Tooltips
+
+**Learning:** Window controls (Minimize, Maximize, Close using `IconMinus`, `IconSquare`, `IconX`) across individual desktop window components in `app/components/windows/` frequently miss explicit `aria-label` attributes (for screen readers) and `title` attributes (for mouse hover tooltips).
+**Action:** When creating tooltips for icon-only elements like window controls, prefer using the native HTML `title` attribute alongside `aria-label` to provide context visually on mouse hover and explicitly for screen readers, without needing additional state or dependencies.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -48,12 +48,16 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           {/* Window Controls */}
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -61,6 +65,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -131,12 +131,16 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -144,6 +148,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -78,12 +78,16 @@ export function BrowserWindow({
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -91,6 +95,8 @@ export function BrowserWindow({
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -71,6 +71,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
           {/* Window Controls */}
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
@@ -78,6 +80,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -85,6 +89,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -47,6 +47,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
               onClick={handleMinimize}
@@ -54,6 +56,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -61,6 +65,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -38,12 +38,16 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -51,6 +55,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -126,12 +126,16 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -139,6 +143,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -43,12 +43,16 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -56,6 +60,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -310,6 +310,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
               className="p-2 rounded-full"
@@ -317,6 +319,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -324,6 +328,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -52,12 +52,16 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -65,6 +69,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -40,18 +40,27 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
           </div>
           <div className="flex items-center gap-4">
             <button
+              aria-label="Minimize"
+              title="Minimize"
               onClick={handleMinimize}
               className="text-white/50 hover:text-white transition-colors"
             >
               <IconMinus size={18} />
             </button>
             <button
+              aria-label="Maximize"
+              title="Maximize"
               onClick={toggleMaximize}
               className="text-white/50 hover:text-white transition-colors"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              aria-label="Close"
+              title="Close"
+              onClick={onClose}
+              className="text-white/50 hover:text-white transition-colors"
+            >
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
🎨 Palette: Add ARIA labels and native tooltips to window controls

💡 What: Injected `aria-label` ("Minimize", "Maximize", "Close") and `title` attributes into the window control buttons across all desktop window components in `app/components/windows/*.tsx`.
🎯 Why: To improve the accessibility of the OS-like interface for screen readers, and provide native hover tooltips for mouse users so the function of the icon-only `IconMinus`, `IconSquare`, and `IconX` buttons is clear without guessing.
📸 Before/After: Visuals remain unchanged; tooltips appear natively on hover.
♿ Accessibility: Ensures window controls meet WCAG standards for interactive elements needing an accessible name.

---
*PR created automatically by Jules for task [4238802390245683046](https://jules.google.com/task/4238802390245683046) started by @Pranav322*