### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to AboutWindow controls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -50,6 +50,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              title="Minimize"
+              aria-label="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -57,6 +59,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              title="Maximize"
+              aria-label="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -64,6 +68,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              title="Close"
+              aria-label="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
🎨 Palette UX Enhancement: Added tooltips and ARIA labels to the window control buttons in `AboutWindow.tsx`.

💡 **What:** Added `title` and `aria-label` attributes to the icon-only `<motion.button>` elements for Minimize, Maximize, and Close actions.
🎯 **Why:** To improve accessibility for screen readers by providing clear button purposes, and to enhance the mouse user experience by displaying native tooltips on hover.
♿ **Accessibility:** Fully accessible window controls with correct ARIA labels.

---
*PR created automatically by Jules for task [3621031957102038537](https://jules.google.com/task/3621031957102038537) started by @Pranav322*