### PR TITLE
🎨 Palette: Add a11y tooltips to window controls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - OS Window Controls Accessibility
+
+**Learning:** In desktop-like OS interfaces, window controls (Minimize, Maximize, Close) are often implemented using generic animated icons (e.g., Framer Motion's `<motion.button>`). Because these icons are self-explanatory to visual users familiar with desktop OS conventions, it's easy to overlook that they are completely opaque to screen readers and lack native hover tooltips.
+**Action:** Always apply `aria-label` and `title` attributes directly to `<motion.button>` wrappers for window controls to ensure semantic parity with native OS interfaces.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -48,12 +48,16 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           {/* Window Controls */}
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
@@ -61,6 +65,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"


### PR DESCRIPTION
💡 What: The UX enhancement added: `aria-label` and `title` attributes were added to the window controls (Minimize, Maximize, Close) in `AboutWindow.tsx`.
🎯 Why: The user problem it solves: Screen readers were unable to discern the function of these icon-only buttons, and mouse users lacked tooltip context, violating native OS interface conventions.
♿ Accessibility: Any a11y improvements made: Improved keyboard/screen reader navigability and provided hover context.

---
*PR created automatically by Jules for task [4432531846180711406](https://jules.google.com/task/4432531846180711406) started by @Pranav322*