### PR TITLE
⚡ Bolt: Optimize terminal scroll ref to fix O(N) re-render issue

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-04-05 - [React Ref O(N) Re-render Issue in Lists]
+
+**Learning:** Attaching a single `ref` to every element inside a `.map()` loop (e.g. `<div ref={scrollRef}>...</div>`) degrades performance by triggering N ref updates on every render where the list changes.
+**Action:** When a scroll-target ref is needed, attach it to a single empty element outside the loop (e.g., `<div ref={scrollRef} />` at the bottom of the list container) instead of to the list items themselves.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -510,6 +505,9 @@ const Terminalcomp = () => {
               </div>
             </div>
           ))}
+
+          {/* Scroll target attached to a single element to avoid O(N) ref updates on re-render */}
+          <div ref={terminalRef} />
 
           {isAskingName && (
             <div className="mb-2 sm:mb-4 text-xs sm:text-sm text-yellow-400">


### PR DESCRIPTION
💡 **What**: Moved `ref={terminalRef}` out of the `commands.map()` loop into a single scroll anchor `div`.
🎯 **Why**: Previously, the ref was being attached to *every* element in the terminal's output loop. This is a React anti-pattern that causes React to perform N ref updates on every render where the list changes, only to have the ref eventually point to the very last element. 
📊 **Impact**: Reduces ref update overhead from O(N) to O(1) on every terminal re-render, keeping the terminal fast even as the command history grows large.
🔬 **Measurement**: Verified visually with Playwright that the terminal still automatically scrolls to the bottom when new commands are entered. Run the app in desktop mode, toggle to terminal, and type commands to see it scroll properly.

---
*PR created automatically by Jules for task [14752942273258720644](https://jules.google.com/task/14752942273258720644) started by @Pranav322*