### PR TITLE
⚡ Bolt: optimize terminal auto-scroll ref attachment

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-04-08 - [O(N) Ref Updates in React Lists]
+
+**Learning:** Attaching a single scroll-target `ref` to every element inside a `.map()` loop in a React component degrades performance. Because the ref changes target N times during rendering, it causes O(N) ref assignments per commit, which can be noticeably slow as lists grow (e.g., in a terminal component history).
+**Action:** Instead of putting the ref on mapped items, always attach the ref to a single empty element (e.g., `<div ref={scrollRef} />`) at the bottom/end of the list container when building auto-scrolling views.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -533,6 +528,8 @@ const Terminalcomp = () => {
               />
             </form>
           </div>
+          {/* ⚡ Bolt: Attached scroll ref to a single empty div instead of mapping over every command, preventing O(N) ref updates per render */}
+          <div ref={terminalRef} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 What:
The optimization implemented moves the React `ref={terminalRef}` from being attached to every single terminal command component mapped in the array, to being attached to a single empty `<div ref={terminalRef} />` at the end of the element tree.

🎯 Why:
The previous approach caused an inefficient React pattern where React would execute a ref update callback for every single rendered command item in the list ($O(N)$ operations). This ref was only needed for the `scrollIntoView` behavior to jump to the latest command anyway.

📊 Impact:
This reduces ref updates during render phases from $O(N)$ (where N is the number of terminal commands in history) to exactly $O(1)$. It prevents linear performance degradation as the user's terminal session grows in command history length.

🔬 Measurement:
Start the app and type numerous commands into the terminal. Profile the commit phases using the React Profiler. You will see far fewer ref mutation lifecycle boundaries being evaluated, and the scroll jump logic will still accurately bring the most recently executed command into the viewport smoothly.

---
*PR created automatically by Jules for task [9479038095248693099](https://jules.google.com/task/9479038095248693099) started by @Pranav322*