### PR TITLE
⚡ Bolt: Optimize Terminal ref assignment loop

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-12 - [Ref Assignment in React Mapped Lists]
+
+**Learning:** Attaching a single scroll-target ref to every element inside a `.map()` loop (e.g., `<div ref={myRef} />` for mapped commands) degrades performance by triggering N ref updates per commit phase. React constantly re-attaches the ref for every item as it renders the list, leading to unnecessary DOM operations and performance overhead, particularly as the list grows.
+**Action:** Always attach such target refs to a single empty element (like `<div ref={myRef} />`) at the bottom of the list when the goal is simply scrolling to the end, thus reducing ref updates from O(N) to O(1).

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -491,13 +491,9 @@ const Terminalcomp = () => {
         <div className="p-1 sm:p-2 text-green-100">
           <TerminalClock />
 
+          {/* ⚡ Bolt: Removed ref from mapped items to prevent N ref updates per render */}
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -510,6 +506,9 @@ const Terminalcomp = () => {
               </div>
             </div>
           ))}
+
+          {/* ⚡ Bolt: Single ref attached here for scrolling */}
+          <div ref={terminalRef} />
 
           {isAskingName && (
             <div className="mb-2 sm:mb-4 text-xs sm:text-sm text-yellow-400">


### PR DESCRIPTION
💡 **What**: Extracted the `ref={terminalRef}` out from inside the `.map()` block iterating over the Terminal commands in `app/components/Terminal/Terminal.tsx`. It is now placed on a single, empty `<div ref={terminalRef} />` at the very end of the commands list.

🎯 **Why**: Previously, the `terminalRef` was being attached to every single command element inside the `.map()`. Because it was the exact same ref object, React had to re-attach and overwrite its `.current` value N times (once for each command) during the commit phase of *every* render cycle. This is a common React performance anti-pattern that causes unnecessary DOM operations and overhead, especially as the list of rendered commands grows.

📊 **Impact**: Reduces ref updates from O(N) to O(1) during the commit phase. The scroll-to-bottom logic remains perfectly functional because the empty div rests precisely where the ref used to point (the bottom of the list).

🔬 **Measurement**: Verify by opening the Terminal in the app, entering multiple commands to populate the history, and ensuring that pressing Enter correctly scrolls to the bottom.

*(Also added this pattern to `.Jules/bolt.md` for future reference)*

---
*PR created automatically by Jules for task [13300318512232093883](https://jules.google.com/task/13300318512232093883) started by @Pranav322*