### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to window controls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -49,6 +49,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -56,6 +58,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -63,6 +67,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -132,6 +132,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -139,6 +141,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -146,6 +150,8 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -79,6 +79,8 @@ export function BrowserWindow({
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -86,6 +88,8 @@ export function BrowserWindow({
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -93,6 +97,8 @@ export function BrowserWindow({
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />
@@ -104,6 +110,8 @@ export function BrowserWindow({
         <div className="flex items-center gap-2 px-4 py-2 bg-gray-900/50 border-b border-white/10">
           <button
             onClick={goBack}
+            aria-label="Go Back"
+            title="Go Back"
             disabled={historyIndex === 0}
             className="p-1.5 rounded-full hover:bg-white/10 disabled:opacity-50 disabled:hover:bg-transparent"
           >
@@ -111,12 +119,19 @@ export function BrowserWindow({
           </button>
           <button
             onClick={goForward}
+            aria-label="Go Forward"
+            title="Go Forward"
             disabled={historyIndex === history.length - 1}
             className="p-1.5 rounded-full hover:bg-white/10 disabled:opacity-50 disabled:hover:bg-transparent"
           >
             <IconArrowRight size={16} className="text-white/80" />
           </button>
-          <button onClick={refresh} className="p-1.5 rounded-full hover:bg-white/10">
+          <button
+            onClick={refresh}
+            aria-label="Refresh"
+            title="Refresh"
+            className="p-1.5 rounded-full hover:bg-white/10"
+          >
             <IconRefresh size={16} className="text-white/80" />
           </button>
           <input

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -73,6 +73,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -80,6 +82,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -87,6 +91,8 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -48,6 +48,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
               onClick={handleMinimize}
             >
@@ -56,6 +58,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -63,6 +67,8 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -39,6 +39,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -46,6 +48,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -53,6 +57,8 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -127,6 +127,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -134,6 +136,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -141,6 +145,8 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -44,6 +44,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -51,6 +53,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -58,6 +62,8 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -312,6 +312,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -319,6 +321,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -326,6 +330,8 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -53,6 +53,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              aria-label="Minimize"
+              title="Minimize"
               className="p-2 rounded-full"
             >
               <IconMinus size={14} className="text-white/80" />
@@ -60,6 +62,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
+              aria-label="Maximize"
+              title="Maximize"
               className="p-2 rounded-full"
             >
               <IconSquare size={14} className="text-white/80" />
@@ -67,6 +71,8 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
+              aria-label="Close"
+              title="Close"
               className="p-2 rounded-full"
             >
               <IconX size={14} className="text-white/80" />


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to all window control buttons (Minimize, Maximize, Close) across the OS-like interface. Added similar attributes to the browser window's back, forward, and refresh buttons.
🎯 **Why:** Icon-only buttons without accessible names are invisible to screen readers, and without tooltips, sighted users may not immediately understand their function.
📸 **Before/After:** No visual changes to layout. Hovering over window controls now reveals native tooltips (e.g., "Minimize", "Close").
♿ **Accessibility:** Screen readers will now announce "Minimize", "Maximize", "Close", "Go Back", "Go Forward", and "Refresh" instead of ignoring the buttons or reading generic elements.

---
*PR created automatically by Jules for task [3845386640809032849](https://jules.google.com/task/3845386640809032849) started by @Pranav322*