### PR TITLE
⚡ Bolt: Optimize Terminal scroll ref

### DIFF
--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -516,6 +511,9 @@ const Terminalcomp = () => {
               Please enter your name to continue:
             </div>
           )}
+          {/* ⚡ Bolt: Moved terminalRef outside the loop to a dedicated bottom element
+              to prevent O(N) ref reassignment overhead during every render cycle. */}
+          <div ref={terminalRef} />
           <div className="flex items-center gap-1 sm:gap-2 text-xs sm:text-sm">
             <span className="text-green-500">{userName || 'guest'}@portfolio</span>
             <span className="text-blue-400">:</span>


### PR DESCRIPTION
💡 **What:** Moved `terminalRef` outside the `.map()` loop rendering commands to a dedicated empty element at the bottom of the list.

🎯 **Why:** Previously, the `terminalRef` was being attached to every item in the command list during the `.map()` execution. This caused React to needlessly assign and re-assign the reference O(N) times on every single render pass when the terminal was updated.

📊 **Impact:** Reduces ref reassignment from O(N) to O(1) during the commit phase, providing a minor performance improvement and eliminating unnecessary work as the command history grows.

🔬 **Measurement:** Verify by typing multiple commands in the Terminal and confirming that the auto-scroll to bottom functionality continues to work flawlessly. Code review confirms `terminalRef` is only assigned once at the end of the history list.

---
*PR created automatically by Jules for task [9305255674843957574](https://jules.google.com/task/9305255674843957574) started by @Pranav322*