### PR TITLE
⚡ Bolt: Optimize Terminal scrolling ref assignment

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -516,6 +511,8 @@ const Terminalcomp = () => {
               Please enter your name to continue:
             </div>
           )}
+          {/* ⚡ Bolt: Attached scroll ref to a single empty div at the end instead of every mapped item to prevent N ref assignments per commit. */}
+          <div ref={terminalRef} />
           <div className="flex items-center gap-1 sm:gap-2 text-xs sm:text-sm">
             <span className="text-green-500">{userName || 'guest'}@portfolio</span>
             <span className="text-blue-400">:</span>


### PR DESCRIPTION
💡 **What:**
Moved the auto-scrolling `terminalRef` from inside the `commands.map()` rendering loop to a single, dedicated empty `<div ref={terminalRef} />` at the very end of the terminal container.

🎯 **Why:**
Previously, every item in the terminal command history was receiving the exact same `terminalRef`. In React, when a ref is passed to multiple elements sequentially in a map, it causes React to repeatedly assign and re-assign the ref (and potentially detach the old ones) N times per render commit. This causes unnecessary overhead that scales linearly O(N) with the number of commands.

📊 **Impact:**
- Eliminates O(N) redundant ref assignments during the commit phase.
- Guarantees the auto-scroll will always target the very bottom of the terminal output reliably.
- Fixes an edge case where auto-scrolling might fail if the terminal `commands` array was entirely empty.

🔬 **Measurement:**
- Verify by opening the CLI terminal mode.
- Enter multiple commands (e.g., `ls`, `help`, `experience`) to ensure the auto-scroll behavior still functions smoothly and drops to the latest output.

---
*PR created automatically by Jules for task [16708968839579938585](https://jules.google.com/task/16708968839579938585) started by @Pranav322*