### PR TITLE
⚡ Bolt: Optimize terminal scroll ref to prevent excessive updates

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2026-04-16 - Prevent Excessive Ref Updates
+**Learning:** In React, attaching a single `ref` inside a `.map()` loop causes the ref to be redundantly reassigned $ times during every commit phase, which is an unnecessary (N)$ operation that slightly degrades performance when the list grows.
+**Action:** Always place scroll-target refs on a single, dedicated empty element (e.g., `<div ref={myRef} />`) at the end of the mapped list rather than attaching it to every rendered item.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -533,6 +528,8 @@ const Terminalcomp = () => {
               />
             </form>
           </div>
+          {/* ⚡ Bolt: Moved terminalRef outside the map loop to prevent N ref updates per commit */}
+          <div ref={terminalRef} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 **What:** Moved `terminalRef` outside of the `commands.map()` loop into a dedicated empty `<div />` at the end of the list.
🎯 **Why:** In React, attaching a single `ref` to every element inside a loop causes it to be continuously overwritten $N$ times during the commit phase. By moving it outside, we prevent an unnecessary $O(N)$ operation on every render.
📊 **Impact:** Reduces redundant ref assignments from $N$ (number of commands) to $1$ per re-render, slightly improving performance and efficiency when the user types many commands.
🔬 **Measurement:** Code logic optimization; verified via React rendering correctness (terminal still auto-scrolls properly).

---
*PR created automatically by Jules for task [11779610423382219979](https://jules.google.com/task/11779610423382219979) started by @Pranav322*