### PR TITLE
🎨 Palette: Add accessibility attributes and focus states to window controls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/ui/ButtonToggle.tsx
+++ b/app/components/ui/ButtonToggle.tsx
@@ -10,8 +10,9 @@ export function ToggleButton({ isCLI, onToggle }: ToggleButtonProps) {
   return (
     <button
       onClick={onToggle}
-      className="fixed bottom-20 sm:bottom-24 right-4 sm:right-8 p-3 sm:p-4 rounded-full bg-white/50 backdrop-blur-sm text-black shadow-lg hover:shadow-xl transform hover:scale-105 active:scale-95 transition-all duration-300 z-50 min-w-[44px] min-h-[44px] flex items-center justify-center"
-      aria-label="Toggle GUI/CLI mode"
+      className="fixed bottom-20 sm:bottom-24 right-4 sm:right-8 p-3 sm:p-4 rounded-full bg-white/50 backdrop-blur-sm text-black shadow-lg hover:shadow-xl transform hover:scale-105 active:scale-95 transition-all duration-300 z-50 min-w-[44px] min-h-[44px] flex items-center justify-center focus-visible:ring-2 focus-visible:ring-black focus-visible:outline-none"
+      aria-label={isCLI ? 'Switch to GUI mode' : 'Switch to CLI mode'}
+      title={isCLI ? 'Switch to GUI mode' : 'Switch to CLI mode'}
     >
       {isCLI ? (
         <Monitor className="w-5 h-5 sm:w-6 sm:h-6" />

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -48,22 +48,28 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           {/* Window Controls */}
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -131,22 +131,28 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -78,22 +78,28 @@ export function BrowserWindow({
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -71,23 +71,29 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
           {/* Window Controls */}
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -47,23 +47,29 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
               onClick={handleMinimize}
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -38,22 +38,28 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -126,22 +126,28 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -43,22 +43,28 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -310,23 +310,29 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -52,22 +52,28 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
           </div>
           <div className="flex items-center gap-1">
             <motion.button
+              aria-label="Minimize window"
+              title="Minimize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Maximize window"
+              title="Maximize"
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
+              aria-label="Close window"
+              title="Close"
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -40,18 +40,27 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
           </div>
           <div className="flex items-center gap-4">
             <button
+              aria-label="Minimize window"
+              title="Minimize"
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={18} />
             </button>
             <button
+              aria-label="Maximize window"
+              title="Maximize"
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              aria-label="Close window"
+              title="Close"
+              onClick={onClose}
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
+            >
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
**What:**
Added `aria-label`, `title` attributes, and `focus-visible:ring-2` to the window control buttons (Minimize, Maximize, Close) and the GUI/CLI Toggle button.

**Why:**
To improve accessibility for screen readers and keyboard users. Previously, the buttons were icon-only without proper ARIA labels, making them invisible to screen readers, and had no clear focus state, making keyboard navigation difficult.

**Before/After:**
Window controls and toggle button now have focus rings and descriptive screen reader text. Tooltips also appear on hover.

**Accessibility:**
- Added clear `aria-label`s for screen readers.
- Added `title`s for visual tooltips on hover.
- Added `focus-visible:ring-2` to ensure keyboard users have a visible indicator when focused.

---
*PR created automatically by Jules for task [7045361450084787933](https://jules.google.com/task/7045361450084787933) started by @Pranav322*