### PR TITLE
⚡ Bolt: Optimize terminal scroll ref attachment

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-05-30 - [Terminal Ref Attachment]
+
+**Learning:** In React components like `Terminal`, avoid attaching a single scroll-target ref to every element inside a `.map()` loop, as it degrades performance by triggering N ref updates per commit.
+**Action:** Instead, attach the ref to a single empty element (e.g., `<div ref={terminalRef} />`) at the end of the list.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -533,6 +528,7 @@ const Terminalcomp = () => {
               />
             </form>
           </div>
+          <div ref={terminalRef} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 What: The optimization implemented
Moves the `terminalRef` attachment from the `commands.map()` loop to a single empty `<div />` element at the end of the terminal content.

🎯 Why: The performance problem it solves
In the original code, `ref={terminalRef}` was being attached to *every* item inside the `commands.map()` loop. React's behavior in this scenario is to continually overwrite the ref during the commit phase for each item, causing $O(N)$ unnecessary ref assignments per render (where N is the number of terminal commands in history). This degrades performance as more commands are entered.

📊 Impact: Expected performance improvement
Reduces ref assignment operations from $O(N)$ to $O(1)$ per render. It also fixes a subtle logical bug where the terminal auto-scrolled to the last executed command, which could potentially leave the active input prompt partially obscured. Now it scrolls properly to the bottom.

🔬 Measurement: How to verify the improvement
Open the terminal, type several commands to populate history, and observe that scrolling works correctly while profiling React to see fewer commit phase updates.

---
*PR created automatically by Jules for task [14771849778414352994](https://jules.google.com/task/14771849778414352994) started by @Pranav322*