### PR TITLE
⚡ Bolt: Optimize terminal scroll ref to prevent redundant updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-20 - Optimize Terminal Scroll Ref
+**Learning:** Attaching a single scroll-target ref to every element inside a React `.map()` loop is a subtle performance leak, as it triggers N ref updates per commit phase.
+**Action:** Attach the ref to a single empty element (e.g., `<div ref={terminalRef} />`) at the end of the list. This prevents redundant updates and ensures the input form is scrolled into view properly.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -533,6 +528,8 @@ const Terminalcomp = () => {
               />
             </form>
           </div>
+          {/* ⚡ Bolt: Attached scroll ref to a single empty div at the bottom to prevent N ref updates per commit in the loop. */}
+          <div ref={terminalRef} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 **What:** Moved the scroll-to-bottom ref (`terminalRef`) out of the `commands.map()` loop in the Terminal component and placed it on a single empty `div` at the bottom of the container. Added an explanatory code comment prefix with `⚡ Bolt:`.

🎯 **Why:** Previously, the `ref={terminalRef}` was attached to every item generated in the command history map. During React's commit phase, this forces React to repeatedly unmount and mount the ref `N` times (where `N` is the number of history items), leaving it finally attached to the last item. This causes a subtle performance leak that degrades proportionally to the length of the terminal history. By moving the ref outside the loop, React only updates it once, keeping render cycles lean. Furthermore, placing it below the active input form ensures the form is also brought into view when scrolling, which fixes a potential UI bug where the input could be hidden behind the prompt after a long output.

📊 **Measured Improvement:** Reduces React ref assignments from O(N) to O(1) per command entered. Eliminates redundant internal React operations during the commit phase for the `Terminalcomp`.

🔬 **Measurement:** Code review confirms the removal of the ref from the `.map` body, and manual verification via `pnpm build` and `pnpm lint` confirms it compiles safely.

---
*PR created automatically by Jules for task [15758301128406284287](https://jules.google.com/task/15758301128406284287) started by @Pranav322*