### PR TITLE
🎨 Palette: Add accessible labels to About window controls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Window Control Accessibility
+
+**Learning:** Custom OS-like window components (`app/components/windows/*`) use generic icon-only buttons (Minimize, Maximize, Close) which lack semantic meaning for screen readers and tooltips for mouse users, causing accessibility and usability issues.
+**Action:** Always provide explicit `aria-label` attributes and native HTML `title` attributes on interactive icon-only wrappers (like `motion.button`) across custom window interfaces to ensure full context for both assistive technologies and pointer users.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -50,6 +50,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
@@ -57,6 +59,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
               className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
@@ -64,6 +68,8 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
               className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
### 💡 What
Added explicit `aria-label` and native HTML `title` attributes to the generic, icon-only buttons (Minimize, Maximize, Close) inside the custom `AboutWindow` component. Also added a journal entry in `.Jules/palette.md` detailing this accessibility practice.

### 🎯 Why
Custom window controls rely purely on icons, which leaves screen reader users without semantic meaning for these interactive elements, and leaves mouse users without contextual tooltips. Adding these standard attributes ensures full context is available regardless of how the user navigates the application.

### 📸 Before/After
- **Before:** Buttons were just `<motion.button>` wrappers around `<IconMinus>`, `<IconSquare>`, `<IconX>`.
- **After:** Buttons now include `aria-label="Minimize"` and `title="Minimize"`, etc., bridging the gap for both assistive technologies and pointer users.

### ♿ Accessibility
- Improves screen reader navigation by supplying clear string values to previously unlabelled interactive controls.
- Improves pointer usability by restoring native hover tooltips on interactive elements.

---
*PR created automatically by Jules for task [7109335368408341835](https://jules.google.com/task/7109335368408341835) started by @Pranav322*