### PR TITLE
⚡ Bolt: Optimize terminalRef assignment

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -533,6 +528,8 @@ const Terminalcomp = () => {
               />
             </form>
           </div>
+          {/* ⚡ Bolt: Attached scroll-target ref to a single empty element outside the loop to prevent N ref updates per commit. */}
+          <div ref={terminalRef} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 What: Moved the `terminalRef` from being inside the command history `.map()` loop to a single standalone `<div ref={terminalRef} />` at the bottom of the Terminal container.
🎯 Why: Attaching a mutable ref object to every item inside a loop causes React to overwrite `ref.current` during the commit phase for every element sequentially. This is a common React anti-pattern that triggers N ref updates per re-render.
📊 Impact: Eliminates N unnecessary ref updates during React's commit phase every time a new command is entered. Also improves scroll-to-bottom reliability to always include the input field.
🔬 Measurement: Verified the code structure using `git diff` and ensured no linting/formatting issues were introduced. You can verify the behavior manually by using the terminal and checking if the scroll reliably hits the bottom without lag.

---
*PR created automatically by Jules for task [7509318072269909451](https://jules.google.com/task/7509318072269909451) started by @Pranav322*