### PR TITLE
⚡ Bolt: Optimize ref assignment in Terminal component

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2025-04-25 - [Terminal Ref Loop Fix]
+**Learning:** Attaching a React ref inside a `.map` block assigns the ref multiple times in a single render loop, causing redundant ref updates that could affect performance.
+**Action:** Move the ref to an empty `<div>` immediately following the loop, particularly for things like "scroll to bottom" behavior.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -492,12 +492,7 @@ const Terminalcomp = () => {
           <TerminalClock />
 
           {commands.map(command => (
-            <div
-              ref={terminalRef}
-              key={command.id}
-              className="mb-2 sm:mb-4"
-              suppressHydrationWarning
-            >
+            <div key={command.id} className="mb-2 sm:mb-4" suppressHydrationWarning>
               <div className="flex gap-1 sm:gap-2 text-xs sm:text-sm flex-wrap">
                 <span className="text-green-500">{userName || 'guest'}@portfolio</span>
                 <span className="text-blue-400">:</span>
@@ -533,6 +528,8 @@ const Terminalcomp = () => {
               />
             </form>
           </div>
+          {/* ⚡ Bolt: Attached ref here instead of inside the map loop above to avoid N ref updates per commit */}
+          <div ref={terminalRef} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 **What:** Moved `terminalRef` from inside the `commands.map` array to an empty `<div>` immediately following the mapped list. Also, added a comment `⚡ Bolt: Attached ref here instead of inside the map loop above to avoid N ref updates per commit` to explain the optimization.

🎯 **Why:** In React, attaching the exact same ref variable inside a loop causes React to unnecessarily reassign the `current` property for every element during the commit phase (so N times instead of 1 time). When the terminal has many commands, this is an inefficient waste of cycles.

📊 **Impact:** Reduces ref updates during render from $O(N)$ (where $N$ is the number of terminal commands) to $O(1)$. This prevents a hidden performance penalty that scales with terminal usage over time.

🔬 **Measurement:** Verify by looking at the React DevTools profiler to measure commit phase duration, or simply trace component rendering and ensure auto-scroll behavior works identically (as scrolling to the bottom of the container also handles bringing the new input properly into view).

---
*PR created automatically by Jules for task [11885072775190078358](https://jules.google.com/task/11885072775190078358) started by @Pranav322*