### PR TITLE
⚡ Bolt: Remove O(N) ref updates per commit in Terminal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-26 - O(N) Ref Updates in Terminal Loop
+**Learning:** Found an anti-pattern in the `Terminal` component where a single `terminalRef` was being attached to every element inside the `commands.map()` loop. This degraded performance by triggering N ref updates per commit (React assigning the ref to each element sequentially, with the last one winning).
+**Action:** Always attach a scroll-target ref to a single empty element (e.g., `<div ref={targetRef} />`) at the end of the list instead of inside the `.map()` loop to avoid unnecessary ref updates during render phases.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -493,7 +493,6 @@ const Terminalcomp = () => {
 
           {commands.map(command => (
             <div
-              ref={terminalRef}
               key={command.id}
               className="mb-2 sm:mb-4"
               suppressHydrationWarning
@@ -533,6 +532,8 @@ const Terminalcomp = () => {
               />
             </form>
           </div>
+          {/* ⚡ Bolt: Attached ref to a single empty element at the end instead of inside the .map() loop to prevent O(N) ref updates per commit */}
+          <div ref={terminalRef} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
💡 **What:**
Moved the `terminalRef` attachment out of the `commands.map()` loop and placed it on a single, empty `<div />` element at the end of the terminal container.

🎯 **Why:**
Previously, the `Terminal` component was attaching the same `terminalRef` to every command element in the loop. During React's commit phase, it sequentially assigned the DOM node of each element to the ref's `.current` property, resulting in O(N) unnecessary ref updates per render (with only the final assignment actually persisting). This degraded performance as the terminal history grew.

📊 **Impact:**
Eliminates O(N) unnecessary ref assignments per render. The ref is now assigned exactly once per commit, improving terminal rendering performance, especially for users with long command histories.

🔬 **Measurement:**
Run the application, open the Terminal, and execute several commands to build up a large history. The terminal should still correctly scroll to the bottom automatically without the unnecessary overhead of N ref reassignments per commit. Tests pass and the application builds successfully.

---
*PR created automatically by Jules for task [12356414502804026441](https://jules.google.com/task/12356414502804026441) started by @Pranav322*