### PR TITLE
⚡ Bolt: Cache Spotify access token promise

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-28 - Spotify Token Caching
+**Learning:** When fetching API tokens in Next.js backend routes (e.g. `lib/spotify.ts`) used by multiple UI components rendering simultaneously, caching the token value after it arrives is insufficient. If 5 components render at once (like Top Tracks, Top Artists, Now Playing), they will fire 5 parallel token requests before the first one resolves. Furthermore, checking expiration time against a default `0` while the promise is still pending will cause concurrent requests to bypass the cache.
+**Action:** Always cache the *Promise* of the token fetch itself, and ensure the cache validity check correctly accounts for the initial pending state (e.g., `tokenExpirationTime === 0`) to properly deduplicate concurrent requests.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,7 +8,12 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
+// ⚡ Bolt: Cache token promise to prevent duplicate concurrent fetch requests
+// on initial render (e.g. Now Playing + Top Tracks + Top Artists).
+let tokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
+async function fetchAccessToken() {
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -21,7 +26,29 @@ async function getAccessToken() {
     }),
   });
 
-  return response.json();
+  const data = await response.json();
+  if (data.access_token) {
+    // ⚡ Bolt: Cache token for duration of expiration, subtracting 1 minute as buffer
+    tokenExpirationTime = Date.now() + (data.expires_in - 60) * 1000;
+  } else {
+    // If we didn't get an access token, clear the promise so we try again next time
+    tokenPromise = null;
+  }
+  return data;
+}
+
+async function getAccessToken() {
+  // ⚡ Bolt: Return cached promise if we are already fetching, OR if the token is still valid.
+  if (tokenPromise && (Date.now() < tokenExpirationTime || tokenExpirationTime === 0)) {
+    return tokenPromise;
+  }
+
+  tokenPromise = fetchAccessToken().catch(err => {
+    tokenPromise = null;
+    throw err;
+  });
+
+  return tokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What:
Implemented an in-memory cache for the Spotify access token fetch Promise in `lib/spotify.ts`. It stores the pending promise and caches the resolved token for its validity duration (minus a 60-second buffer).

🎯 Why:
Previously, the `getAccessToken()` function was called by `getNowPlaying()`, `getTopTracks()`, `getTopArtists()`, `getPlaylists()`, and `getRecentlyPlayed()`. Because it made an HTTP request on every call without caching, loading the Spotify UI components simultaneously triggered up to 5 redundant backend token fetches in parallel. 

📊 Impact:
Reduces Spotify Token API requests from multiple redundant calls per page-load to exactly 1 request per hour across all endpoints.

🔬 Measurement:
Start the application and monitor network requests or add a console.log in `fetchAccessToken()`. Opening the Spotify Window with all components will now trigger exactly one token fetch instead of five.

---
*PR created automatically by Jules for task [5858835038066428482](https://jules.google.com/task/5858835038066428482) started by @Pranav322*