### PR TITLE
🎨 Palette: Add accessibility attributes to window controls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-05-18 - Desktop Window Control Accessibility
+
+**Learning:** Window control buttons (Minimize, Maximize, Close) in custom desktop window components across this app consistently lack `aria-label`, `title`, and `focus-visible` attributes, rendering them inaccessible to screen readers and keyboard users.
+**Action:** Ensure all interactive icon-only elements, especially recurring window controls across the `app/components/windows/` directory, are explicitly labeled with `aria-label`/`title` and have clear focus states (`focus-visible:ring-2 focus-visible:outline-none`).

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -49,21 +49,27 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -132,21 +132,27 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -73,21 +73,27 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -48,7 +48,9 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
               onClick={handleMinimize}
             >
               <IconMinus size={14} className="text-white/80" />
@@ -56,14 +58,18 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -39,21 +39,27 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -127,21 +127,27 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -44,21 +44,27 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -312,21 +312,27 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -53,21 +53,27 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label="Maximize"
+              title="Maximize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
### 💡 What:
Added `aria-label`, `title`, and `focus-visible` classes to all window control buttons (Minimize, Maximize, Close) across the 9 custom OS desktop window components in `app/components/windows/`.

### 🎯 Why:
The window controls relied purely on icon visuals (`IconMinus`, `IconSquare`, `IconX`) and lacked native tooltips or screen reader accessible names. By explicitly labeling them, we improve the experience for both screen reader users and those navigating with a keyboard or mouse.

### 📸 Before/After:
**Before:**
```tsx
<motion.button className="p-2 rounded-full">
  <IconMinus size={14} className="text-white/80" />
</motion.button>
```

**After:**
```tsx
<motion.button
  aria-label="Minimize"
  title="Minimize"
  className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
>
  <IconMinus size={14} className="text-white/80" />
</motion.button>
```

### ♿ Accessibility:
*   Added explicit `aria-label` to provide context for screen readers.
*   Added native `title` attribute for mouse hover tooltips.
*   Added `focus-visible:ring-2 focus-visible:outline-none` so keyboard navigators have a clear indication of focus state.

---
*PR created automatically by Jules for task [11997144752505764275](https://jules.google.com/task/11997144752505764275) started by @Pranav322*