### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent concurrent duplicate API calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,6 @@
+## 2024-03-XX - Initial Learnings
+**Learning:** We need to find an optimization specific to this repository. Let's look for caching opportunities.
+**Action:** Investigating `lib/spotify.ts` for Promise caching, as it appears in memory.
+## 2024-03-XX - Duplicate API Calls from Concurrent Rendering
+**Learning:** In Next.js/React applications with multiple independent components requesting the same API data (like the Spotify access token), a standard caching pattern checking `if (cachedToken)` is insufficient if the first fetch is still pending. Concurrent components will bypass the cache, resulting in duplicate network requests.
+**Action:** When caching asynchronous data used by multiple components, always cache the `Promise` of the fetch request rather than the resolved value. Additionally, reset the expiration timer while the request is in flight to prevent the "thundering herd" problem during token refresh windows.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,25 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt: Cache the Promise of the access token request.
+// This prevents multiple concurrent components from firing duplicate token requests
+// while the initial token request is still pending.
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it exists and hasn't expired (or is still pending)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset the expiration time while the request is pending to prevent concurrent requests
+  // from bypassing the cache during the refresh window
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +36,21 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(res => res.json())
+    .then(data => {
+      // Set expiration time with a 60-second buffer
+      tokenExpirationTime = Date.now() + (data.expires_in - 60) * 1000;
+      return data;
+    })
+    .catch(error => {
+      // Clear the cache on failure so we can retry
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Caches the `Promise` of the Spotify access token fetch request in memory, rather than fetching a new token on every API call. It correctly handles concurrent requests while the initial token is resolving by reusing the same Promise, and it includes a mechanism to manage token expiration (with a 60-second buffer).

🎯 Why: The previous implementation fetched a fresh Spotify access token on *every single API request* (`/api/spotify/now-playing`, `/api/spotify/top-tracks`, etc.). When multiple Spotify-related widgets load simultaneously on the frontend, this caused multiple redundant external API calls, wasting bandwidth, delaying render times, and risking rate limiting from Spotify.

📊 Impact: Reduces external authentication requests from N (where N is the number of Spotify endpoints hit concurrently or sequentially) to exactly 1 request per ~59 minutes. This significantly speeds up API response times for any endpoint relying on `getAccessToken()`.

🔬 Measurement: Verify the improvement by rendering multiple Spotify widgets simultaneously and observing the Network tab (or terminal logs if logging were added). You will see only one call to `https://accounts.spotify.com/api/token` instead of multiple.

---
*PR created automatically by Jules for task [2038614388555733795](https://jules.google.com/task/2038614388555733795) started by @Pranav322*