### PR TITLE
⚡ Bolt: Cache Spotify access token Promise to prevent redundant API calls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
-## 2025-02-12 - [Conditional Rendering vs Code Splitting]
-**Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
-**Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2026-04-30 - Cached Spotify Access Token Promise
+
+**Learning:** Concurrent data fetching in React Server Components or simultaneous client requests can trigger redundant, unbatched calls to authentication endpoints if the token request isn't cached as a pending Promise. Caching just the resolved token still leaves a window where multiple components can initiate duplicate requests while the first request is pending.
+**Action:** When implementing an in-memory cache for a pending Promise that tracks expiration time, cache the Promise itself and ensure the cache validation logic correctly evaluates the initial pending state (e.g., tokenExpirationTime === 0) so concurrent requests do not inadvertently bypass the cache while the first request is still resolving.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,24 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it exists and hasn't expired.
+  // Note: tokenExpirationTime === 0 means the initial request is still pending,
+  // so we should return the pending promise instead of firing a new request.
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || tokenExpirationTime > now)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration time to 0 while we're fetching to ensure concurrent requests during the refresh window also use this promise.
+  tokenExpirationTime = 0;
+
+  // ⚡ Bolt: Cache the Promise to prevent concurrent redundant API calls during multiple component renders
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +35,20 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      const data = await response.json();
+      // Cache the token for `expires_in` seconds (usually 3600), minus a 1-minute buffer
+      tokenExpirationTime = now + (data.expires_in - 60) * 1000;
+      return data;
+    })
+    .catch(error => {
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 **What:** Implemented an in-memory cache for the Spotify access token that caches the pending Promise of the fetch request.
🎯 **Why:** Previously, if multiple components (e.g., NowPlaying, TopTracks) requested data simultaneously when the token was expired (or on initial load), each component would independently trigger a token refresh request. This caching mechanism prevents "cache stampede" and redundant network calls by allowing concurrent requests to piggyback on the same pending Promise.
📊 **Impact:** Reduces redundant token requests to the Spotify API, improving application responsiveness when multiple Spotify widgets load concurrently.
🔬 **Measurement:** Can be verified by observing the network tab in browser dev tools or application logs when opening the Spotify window with multiple concurrent data fetches. Only one `/api/token` request should be made.

---
*PR created automatically by Jules for task [16830668628479918597](https://jules.google.com/task/16830668628479918597) started by @Pranav322*