### PR TITLE
🎨 Palette: Add accessibility to Spotify window controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2024-05-01 - Spotify Window Accessibility
+**Learning:** Icon-only window controls in SpotifyWindow lacked ARIA labels and focus-visible styling, hindering keyboard accessibility.
+**Action:** Ensure all future window components include aria-labels and proper focus styles on minimize/maximize/close controls.

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -41,17 +41,26 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
           <div className="flex items-center gap-4">
             <button
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
+              className="text-white/50 hover:text-white transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
               <IconMinus size={18} />
             </button>
             <button
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Maximize"
+              title="Maximize"
+              className="text-white/50 hover:text-white transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className="text-white/50 hover:text-white transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+            >
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `title`, and `focus-visible` styling to the minimize, maximize, and close controls in `SpotifyWindow.tsx`.
🎯 **Why:** The icon-only window control buttons lacked accessible names and visible focus states, making them difficult to use for keyboard-only users or those relying on screen readers.
📸 **Before/After:** No visual changes for mouse users, but keyboard users will now see a focus ring when navigating to these buttons.
♿ **Accessibility:** Added `aria-label`s for screen readers and `focus-visible:ring-2` for visual focus indication.

---
*PR created automatically by Jules for task [9098709750767253008](https://jules.google.com/task/9098709750767253008) started by @Pranav322*