### PR TITLE
⚡ Bolt: Cache Spotify token Promise to prevent redundant concurrent API requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-05-02 - [Caching Async API Promises]
+**Learning:** When caching asynchronous API tokens (like the Spotify access token), cache the `Promise` of the fetch request rather than just the resolved token. This prevents duplicate concurrent network requests to the endpoint when multiple components that rely on the data render simultaneously. Additionally, explicitly check `!response.ok` and throw an error before parsing JSON to prevent silently caching failed HTTP responses.
+**Action:** Always cache the pending Promise object for global async singletons accessed concurrently, and validate HTTP responses before resolving the cached state.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,7 +8,13 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
+// ⚡ Bolt: Cache the pending Promise to prevent duplicate concurrent token requests
+// when multiple Spotify components mount simultaneously, and cache the resolved token
+// until shortly before it expires to reduce network overhead.
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
+async function fetchNewToken() {
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -21,7 +27,29 @@ async function getAccessToken() {
     }),
   });
 
-  return response.json();
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Spotify token: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  // Buffer by 5 minutes (300 seconds)
+  tokenExpirationTime = Date.now() + ((data.expires_in || 3600) - 300) * 1000;
+  return data;
+}
+
+async function getAccessToken() {
+  // ⚡ Bolt: tokenExpirationTime === 0 ensures we don't bypass cache while the first request is still pending
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || Date.now() < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  tokenExpirationTime = 0;
+  cachedTokenPromise = fetchNewToken().catch(err => {
+    cachedTokenPromise = null;
+    throw err;
+  });
+
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 **What:**
Implemented an in-memory cache in `lib/spotify.ts` for the Spotify API access token fetch Promise. The cache stores the pending `Promise` itself and tracks its expiration time.

🎯 **Why:**
When the `SpotifyWindow` mounts, it simultaneously renders multiple subcomponents (`NowPlaying`, `TopTracks`, `TopArtists`, `Playlists`, `RecentlyPlayed`). Previously, each of these components would independently call `getAccessToken()`, resulting in 5 concurrent `POST` requests to the Spotify token endpoint. This creates redundant network overhead and risks hitting rate limits.

📊 **Impact:**
Reduces the number of token refresh requests on window mount from 5 concurrent calls down to exactly 1 call. Subsequent calls resolve instantly using the cached token until shortly before its expiration.

🔬 **Measurement:**
Verified locally via a proxy test script (`test-spotify-fetch.ts`) that triggered 5 parallel `getAccessToken()` calls and confirmed only 1 outbound fetch was executed to the Spotify endpoint.

---
*PR created automatically by Jules for task [16589688770268069059](https://jules.google.com/task/16589688770268069059) started by @Pranav322*