### PR TITLE
🎨 Palette: Improve accessibility of About Me window controls and links

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -49,21 +49,27 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
+              aria-label="Maximize"
+              title="Maximize"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
+              aria-label="Close"
+              title="Close"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>
@@ -97,13 +103,17 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
                   >
                     <span>📧</span> <p className="text-white/90">pranavdotdev@gmail.com</p>
                   </motion.a>
-                  <motion.button
+                  <motion.a
                     whileHover={{ scale: 1.05 }}
-                    className="flex items-center gap-2 px-4 py-2 bg-white/5 rounded-full hover:bg-white/10 transition-colors"
-                    onClick={() => window.open('https://github.com/Pranav322', '_blank')}
+                    className="flex items-center gap-2 px-4 py-2 bg-white/5 rounded-full hover:bg-white/10 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                    href="https://github.com/Pranav322"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="GitHub Profile"
+                    title="GitHub Profile"
                   >
                     <span>🔗</span> <p className="text-white/90">github.com/pranav322</p>
-                  </motion.button>
+                  </motion.a>
                 </div>
               </motion.div>
 


### PR DESCRIPTION
💡 **What:** Added missing `aria-label`, `title`, and `focus-visible` classes to the minimize, maximize, and close buttons in `AboutWindow.tsx`. Refactored the GitHub link from a `<motion.button>` with an `onClick` handler to a semantic `<motion.a>` element with standard `href`, `target="_blank"`, and `rel="noopener noreferrer"` attributes.
🎯 **Why:** To improve keyboard navigation and screen reader support for the `About Me` window. The previous implementation hid crucial interactive controls from assistive technologies and improperly used buttons for external navigation.
📸 **Before/After:** Visually identical in default state. The buttons now have tooltips on hover and clear visual rings when focused via keyboard.
♿ **Accessibility:**
- Added clear textual names (`aria-label`) to icon-only controls.
- Added native browser tooltips (`title`) for visual users hovering over icons.
- Added visual focus indicators (`focus-visible:ring-2`) for keyboard users.
- Restored semantic HTML by using an `<a>` tag for an external outbound link instead of an imperative JavaScript `window.open`.

---
*PR created automatically by Jules for task [5674279297414907526](https://jules.google.com/task/5674279297414907526) started by @Pranav322*