### PR TITLE
⚡ Bolt: Cache Spotify access token promise

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,20 +8,59 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${basic}`,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: refresh_token!,
-    }),
-  });
+// ⚡ Bolt: Cache the access token promise to prevent duplicate concurrent network requests
+// when multiple components (NowPlaying, TopTracks, etc.) render simultaneously.
+let tokenPromiseCache: Promise<any> | null = null;
+let tokenExpirationTime = 0;
 
-  return response.json();
+async function getAccessToken() {
+  const now = Date.now();
+
+  // If we have a cached promise and it hasn't expired, return it immediately
+  if (tokenPromiseCache && now < tokenExpirationTime) {
+    return tokenPromiseCache;
+  }
+
+  // Create a new promise and cache it
+  tokenPromiseCache = (async () => {
+    const response = await fetch(TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${basic}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refresh_token!,
+      }),
+    });
+
+    if (!response.ok) {
+      // Clear the cache on failure so the next request can try again
+      tokenPromiseCache = null;
+      throw new Error(`Failed to fetch Spotify access token: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Spotify tokens typically expire in 3600 seconds (1 hour)
+    // We set expiration slightly earlier (55 minutes) to be safe
+    // If expires_in isn't provided, default to 55 minutes
+    const expiresInSeconds = data.expires_in || 3600;
+    tokenExpirationTime = now + (expiresInSeconds - 300) * 1000;
+
+    return data;
+  })();
+
+  // Evaluate tokenExpirationTime === 0 check to ensure we don't inadvertently
+  // bypass the cache while the first request is still resolving
+  // Setting an arbitrary initial expiration ensures subsequent synchronous callers
+  // hit the cached promise instead of triggering a new fetch
+  if (tokenExpirationTime === 0) {
+    tokenExpirationTime = now + 10000;
+  }
+
+  return tokenPromiseCache;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 **What:** Implemented an in-memory cache for the Spotify access token promise in `lib/spotify.ts`.\n🎯 **Why:** When multiple components that depend on Spotify data (e.g., `NowPlaying`, `TopTracks`, `RecentlyPlayed`) render simultaneously, they trigger duplicate concurrent network requests to the `/api/token` endpoint. Caching the promise ensures only one request is sent and the response is shared.\n📊 **Impact:** Reduces redundant token requests during initial component loads. For a page with 3 Spotify widgets, this reduces token fetches from 3 to 1.\n🔬 **Measurement:** Open the network tab and observe `/api/token` requests when the Spotify window is opened or refreshed.

---
*PR created automatically by Jules for task [13437158914560979056](https://jules.google.com/task/13437158914560979056) started by @Pranav322*