### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent redundant API calls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,7 +8,12 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
+// ⚡ Bolt: Cache Spotify access token promise to prevent duplicate API requests
+// and potential rate limiting when multiple components render concurrently.
+let tokenPromise: Promise<{ access_token: string; expires_in: number }> | null = null;
+let tokenExpirationTime = 0;
+
+async function fetchNewToken() {
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -21,7 +26,32 @@ async function getAccessToken() {
     }),
   });
 
-  return response.json();
+  if (!response.ok) {
+    throw new Error('Failed to fetch Spotify access token');
+  }
+
+  const data = await response.json();
+  // Set expiration time 60 seconds early to prevent edge cases
+  tokenExpirationTime = Date.now() + (data.expires_in - 60) * 1000;
+  return data;
+}
+
+async function getAccessToken() {
+  const now = Date.now();
+  // Return the pending or resolved promise if it exists and hasn't expired
+  // Check tokenExpirationTime === 0 to ensure we don't bypass cache while fetchNewToken is pending
+  if (tokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return tokenPromise;
+  }
+
+  tokenExpirationTime = 0; // Reset expiration while fetching
+  tokenPromise = fetchNewToken().catch(err => {
+    tokenPromise = null;
+    tokenExpirationTime = 0;
+    throw err;
+  });
+
+  return tokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory cache for the Spotify access token fetch Promise in `lib/spotify.ts` with explicit tracking of expiration times.
🎯 Why: The Spotify data fetching functions (like Now Playing, Top Tracks, Top Artists) were each requesting a new access token whenever multiple components rendered concurrently. This resulted in duplicate network calls and potential API rate-limiting or errors due to thundering herd problems. 
📊 Impact: Consolidates concurrent token requests into a single network call. Decreases external API usage substantially during concurrent rendering and component mount events.
🔬 Measurement: Verify by executing a concurrent load (e.g., launching the SpotifyWindow while also navigating through multiple components utilizing the token endpoints) and observing network traffic to `accounts.spotify.com/api/token`. Only one token request will occur if the cache resolves within the expiration window.

---
*PR created automatically by Jules for task [8655580138243127960](https://jules.google.com/task/8655580138243127960) started by @Pranav322*