### PR TITLE
🎨 Palette: Add focus styles to mode toggle button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-05-04 - Floating Action Buttons Focus States
+**Learning:** Fixed position or "floating" icon buttons (like mode toggles) are often easily missed by keyboard users if they lack distinct focus styles, as browser default focus rings can blend into the background or be overridden by other utilities.
+**Action:** Always explicitly define `focus-visible` ring utilities (e.g., `focus-visible:ring-2 focus-visible:ring-blue-500`) on floating action buttons to ensure they have high visibility when navigated via keyboard.

--- a/app/components/ui/ButtonToggle.tsx
+++ b/app/components/ui/ButtonToggle.tsx
@@ -10,7 +10,7 @@ export function ToggleButton({ isCLI, onToggle }: ToggleButtonProps) {
   return (
     <button
       onClick={onToggle}
-      className="fixed bottom-20 sm:bottom-24 right-4 sm:right-8 p-3 sm:p-4 rounded-full bg-white/50 backdrop-blur-sm text-black shadow-lg hover:shadow-xl transform hover:scale-105 active:scale-95 transition-all duration-300 z-50 min-w-[44px] min-h-[44px] flex items-center justify-center"
+      className="fixed bottom-20 sm:bottom-24 right-4 sm:right-8 p-3 sm:p-4 rounded-full bg-white/50 backdrop-blur-sm text-black shadow-lg hover:shadow-xl transform hover:scale-105 active:scale-95 transition-all duration-300 z-50 min-w-[44px] min-h-[44px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       aria-label={isCLI ? 'Switch to GUI mode' : 'Switch to CLI mode'}
       title={isCLI ? 'Switch to GUI mode' : 'Switch to CLI mode'}
     >


### PR DESCRIPTION
💡 **What:** Added distinct `focus-visible` ring styles to the CLI/GUI mode toggle button.
🎯 **Why:** Keyboard users navigating the UI might miss the floating action button at the bottom of the screen since default browser focus styles were being overridden or weren't sufficiently distinct against the background.
📸 **Before/After:** Before, focusing the toggle button had no clear visual indicator. After, a distinct blue ring appears (`focus-visible:ring-blue-500`) when focused via keyboard.
♿ **Accessibility:** Improves keyboard navigability and WCAG 2.4.7 Focus Visible compliance by explicitly adding `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` to the button.

---
*PR created automatically by Jules for task [7290843676739459410](https://jules.google.com/task/7290843676739459410) started by @Pranav322*