### PR TITLE
⚡ Bolt: Cache Spotify Token Promise

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-12 - Promise Caching for Concurrent Requests
+**Learning:** When multiple React components simultaneously trigger data fetches on mount (like multiple Spotify components on one dashboard), caching just the resolved API token isn't enough. If they fire at the exact same time before the first token resolves, they will all make duplicate network requests.
+**Action:** Cache the fetch `Promise` itself rather than just the resolved result. This ensures that concurrent callers will `await` the same pending request instead of triggering their own. Explicitly handle HTTP errors before parsing JSON to avoid silently caching a bad response without `expires_in` fields.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,28 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt: Cache the Promise of the access token fetch to prevent multiple components from making concurrent duplicate requests on mount
+let tokenPromiseCache: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  if (tokenPromiseCache && tokenExpirationTime === 0) {
+    // A request is currently in flight, let's wait for it
+    return tokenPromiseCache;
+  }
+
+  if (tokenPromiseCache && now < tokenExpirationTime) {
+    // We have a cached response that is still valid
+    return tokenPromiseCache;
+  }
+
+  // Reset expiration so concurrent callers know a refresh is in flight
+  tokenExpirationTime = 0;
+
+  // Create a new promise and cache it immediately so concurrent calls will await this same promise
+  tokenPromiseCache = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +39,21 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
+  }).then(async (response) => {
+    if (!response.ok) {
+      tokenPromiseCache = null; // Clear cache on error
+      throw new Error(`Failed to fetch token: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json();
+    // Cache the expiration time, subtracting a small buffer (5 minutes) to ensure token doesn't expire during use
+    tokenExpirationTime = Date.now() + (data.expires_in - 300) * 1000;
+    return data;
+  }).catch((error) => {
+    tokenPromiseCache = null; // Clear cache on error
+    throw error;
   });
 
-  return response.json();
+  return tokenPromiseCache;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 **What:** 
Implemented a Promise cache for the Spotify `getAccessToken` fetch request. It now caches the `Promise` itself, along with an expiration timestamp.

🎯 **Why:** 
Previously, if multiple Spotify components (e.g., `NowPlaying`, `TopTracks`, `RecentlyPlayed`) mounted simultaneously, they would all call `getAccessToken` at the exact same time. Since the token wasn't resolved yet, this triggered multiple duplicate network requests to the Spotify token endpoint. Caching the `Promise` ensures that concurrent callers will `await` the same in-flight request.

📊 **Impact:** 
Reduces the number of network requests to the Spotify token endpoint from N (number of concurrent components) to 1 on initial load and during token refreshes. This saves network bandwidth, speeds up the loading of Spotify components, and avoids hitting rate limits.

🔬 **Measurement:** 
1. Open the Spotify Window in the application.
2. Check the Network tab in Developer Tools.
3. Observe that there is only one request to the `/api/token` endpoint instead of multiple requests firing simultaneously.

---
*PR created automatically by Jules for task [4759920555353112067](https://jules.google.com/task/4759920555353112067) started by @Pranav322*