### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent redundant network requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-13 - [Promise Caching for External API Calls]
+**Learning:** Concurrent UI components fetching from the same external token endpoint (e.g., Spotify Access Token) can trigger multiple simultaneous network requests, bypassing normal cache headers. Storing the pending `Promise` instead of just the resolved token correctly prevents these redundant requests.
+**Action:** When creating token fetchers shared across multiple components rendering simultaneously, cache the fetch `Promise` itself and check for failure (`!response.ok`) before caching to avoid poisoning the cache with failed requests.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,16 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let tokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  if (tokenPromise && (tokenExpirationTime === 0 || Date.now() < tokenExpirationTime)) {
+    return tokenPromise;
+  }
+
+  tokenExpirationTime = 0; // Reset to 0 while fetching to allow concurrent components to share the promise
+  tokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +27,24 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        tokenPromise = null;
+        throw new Error('Failed to fetch Spotify access token');
+      }
+      const data = await response.json();
+      // Spotify tokens typically expire in 3600 seconds (1 hour)
+      // We'll expire it a bit early (e.g., 5 minutes early) to be safe
+      tokenExpirationTime = Date.now() + (data.expires_in - 300) * 1000;
+      return data;
+    })
+    .catch(error => {
+      tokenPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return tokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented Promise-based caching for the Spotify access token with expiration tracking.
🎯 Why: Multiple UI components (Now Playing, Top Tracks, Top Artists) were firing concurrent requests to the Spotify token endpoint, leading to redundant network calls and potential rate limiting.
📊 Impact: Reduces redundant network requests to the Spotify token endpoint by caching the pending promise.
🔬 Measurement: Check the network tab or console logs to verify that only a single request is made to the Spotify token endpoint on initial load or token expiration.

---
*PR created automatically by Jules for task [457771789608685180](https://jules.google.com/task/457771789608685180) started by @Pranav322*