### PR TITLE
⚡ Bolt: Cache Spotify access token promise

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-13 - [Caching Promises for Concurrent Requests]
+**Learning:** When implementing an in-memory cache for a pending Promise that also tracks an expiration time, the initial pending state must be carefully considered. If the cache validation logic strictly checks `Date.now() < tokenExpirationTime`, concurrent requests will bypass the cache because `tokenExpirationTime` remains `0` while the first request is still resolving.
+**Action:** When caching a Promise and using an expiration time, ensure the condition correctly evaluates the pending state (e.g., checking if `tokenExpirationTime === 0` along with the current time) so that concurrent requests effectively wait for the same resolving Promise.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,16 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let tokenCachePromise: Promise<{ access_token: string; expires_in: number }> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  // ⚡ Bolt: Cache Spotify access token promise to prevent duplicate concurrent network requests
+  if (tokenCachePromise && (tokenExpirationTime === 0 || Date.now() < tokenExpirationTime)) {
+    return tokenCachePromise;
+  }
+
+  tokenCachePromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +27,22 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        tokenCachePromise = null;
+        throw new Error(`Failed to fetch Spotify token: ${response.statusText}`);
+      }
+      const data = await response.json();
+      tokenExpirationTime = Date.now() + data.expires_in * 1000 - 60000;
+      return data;
+    })
+    .catch(error => {
+      tokenCachePromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return tokenCachePromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Cached the Spotify access token Promise in-memory and added expiration tracking (1-minute buffer before actual expiration).
🎯 Why: To prevent concurrent duplicate network requests to the Spotify API token endpoint when multiple components (like Now Playing, Top Tracks, etc.) render simultaneously on page load.
📊 Impact: Eliminates redundant token API calls (which happen before every Spotify data fetch), significantly speeding up overall Spotify widget loading and avoiding rate limits.
🔬 Measurement: Verify network tab (or server logs) when loading the page; there should be only one request to the Spotify token endpoint even if multiple Spotify components load simultaneously.

---
*PR created automatically by Jules for task [8295815764711355005](https://jules.google.com/task/8295815764711355005) started by @Pranav322*