### PR TITLE
🎨 Palette: Make custom wallpaper upload keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Accessible Custom File Uploads
+**Learning:** Using Tailwind's `hidden` class (`display: none`) on native `<input type="file">` elements to create custom upload buttons removes the element entirely from the accessibility tree, making it undiscoverable by screen readers and unreachable via keyboard tabbing.
+**Action:** Always use `sr-only` to visually hide native inputs while preserving accessibility. To provide visual feedback for keyboard users, apply `focus-within:ring-2` (and related styling) to the surrounding `<label>` element that acts as the custom button.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,19 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label
+                htmlFor="wallpaper-upload"
+                className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-blue-400 focus-within:outline-none"
+              >
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
+                  id="wallpaper-upload"
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
+                  aria-label="Upload custom wallpaper"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What: Replaced `hidden` with `sr-only` on the wallpaper upload file input and added a visual focus indicator (`focus-within:ring-2 focus-within:ring-blue-400 focus-within:outline-none`) to its container `<label>`. Also added `id`, `htmlFor`, and `aria-label`.
🎯 Why: Previously, keyboard-only and screen reader users could not discover or interact with the custom wallpaper upload functionality because `display: none` completely removes elements from the accessibility tree and tab order.
📸 Before/After: N/A (Visual change only applies when navigating via keyboard `Tab`).
♿ Accessibility: The file input is now focusable via keyboard, shows a clear visual indicator when focused, and is properly exposed to screen readers.

---
*PR created automatically by Jules for task [16229037313607141955](https://jules.google.com/task/16229037313607141955) started by @Pranav322*