### PR TITLE
⚡ Bolt: Cache Spotify access token Promise to prevent duplicate network requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-01-09 - Caching Pending Promises for Spotify API Tokens
+
+**Learning:** Concurrent components rendering simultaneously trigger duplicate fetch requests to the Spotify token endpoint before the first request resolves, bypassing standard token caching. Furthermore, caching failed HTTP responses (like 429s) without explicitly checking !response.ok corrupts the cache state.
+**Action:** Always cache the Promise of the fetch request rather than just the resolved token, and explicitly evaluate the initial pending state (e.g., tokenExpirationTime === 0) to prevent concurrent bypasses. Additionally, explicitly check and throw on !response.ok to avoid caching invalid token states.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,7 +8,12 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
+// ⚡ Bolt: Cache the Promise of the token fetch to prevent multiple concurrent requests
+// from components that render simultaneously before the first request completes.
+let tokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
+async function fetchAccessToken() {
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -21,7 +26,34 @@ async function getAccessToken() {
     }),
   });
 
-  return response.json();
+  // ⚡ Bolt: Explicitly check for failed HTTP responses before parsing JSON
+  // to avoid silently caching invalid data (like 429s) which lacks 'expires_in'
+  if (!response.ok) {
+    throw new Error(`Failed to fetch access token: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  // Set expiration slightly early to avoid edge-case failures
+  tokenExpirationTime = Date.now() + (data.expires_in - 60) * 1000;
+  return data;
+}
+
+async function getAccessToken() {
+  // ⚡ Bolt: Evaluate tokenExpirationTime === 0 to ensure concurrent requests
+  // await the initial pending tokenPromise instead of starting a duplicate request.
+  if (tokenPromise && (tokenExpirationTime === 0 || Date.now() < tokenExpirationTime)) {
+    return tokenPromise;
+  }
+
+  tokenExpirationTime = 0; // Reset explicitly so concurrent requests await the new fetch
+  tokenPromise = fetchAccessToken().catch(error => {
+    // Reset cache on error so subsequent requests can try again
+    tokenPromise = null;
+    tokenExpirationTime = 0;
+    throw error;
+  });
+
+  return tokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory cache for the Spotify access token fetch request by caching the Promise and evaluating the pending state. Added checks to prevent caching failed responses.

🎯 Why: Multiple concurrent component renders would trigger duplicate calls to the token endpoint before the first request resolved, bypassing the cache and risking rate limits.

📊 Impact: Reduces duplicate token fetch requests from concurrent components down to 1. Reuses valid tokens to reduce network latency.

🔬 Measurement: Monitor the network tab while opening the SpotifyStats window to observe only one token fetch is made.

---
*PR created automatically by Jules for task [4165904376589702931](https://jules.google.com/task/4165904376589702931) started by @Pranav322*