### PR TITLE
🎨 Palette: File Upload Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2024-05-10 - File Upload Accessibility
+**Learning:** Custom file upload UI using `<label>` with an internal `input type="file"` often uses `className="hidden"` to hide the ugly default input. This removes the input from the accessibility tree, breaking keyboard navigation.
+**Action:** Always use `.sr-only` to visually hide `<input type="file">` elements while preserving accessibility. Combine this with `focus-within:ring-*` on the parent `<label>` to display focus states correctly when keyboard users tab to the input.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-blue-400 focus-within:outline-none">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What: Replaced the `hidden` class with `sr-only` on the file upload input and added `focus-within:ring-2 focus-within:ring-blue-400 focus-within:outline-none` to its wrapper `<label>` in `SettingsWindow.tsx`.
🎯 Why: Using `className="hidden"` completely removes the input from the accessibility tree, making it impossible for keyboard users to navigate to the file upload button.
📸 Before/After: Visual changes apply only when focused via keyboard (a blue outline appears).
♿ Accessibility: The file input is now screen-reader friendly and keyboard navigable. Keyboard users can focus on it and use the `Space` or `Enter` keys to trigger the file picker.

---
*PR created automatically by Jules for task [16954989650409159509](https://jules.google.com/task/16954989650409159509) started by @Pranav322*