### PR TITLE
🎨 Palette: Make custom file upload keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-14 - Custom File Upload Keyboard Accessibility
+**Learning:** Using Tailwind's `hidden` class on custom `<input type="file">` elements removes them from the accessibility tree and breaks keyboard tab navigation.
+**Action:** Always use `sr-only` on the input element and apply `focus-within` styles (e.g., `focus-within:ring-2`) to its wrapping `<label>` to preserve visual focus states for keyboard users.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,15 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-blue-400 focus-within:outline-none transition-shadow">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
+                  aria-label="Upload custom wallpaper"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What: Changed the file input class from `hidden` to `sr-only` and added `focus-within` utility classes to its wrapping label.

🎯 Why: The `hidden` class completely removes the file input from the accessibility tree and keyboard tab order, preventing keyboard users from uploading custom wallpapers.

📸 Before/After: N/A

♿ Accessibility: Restores keyboard navigability and provides a clear visual focus ring when the upload area is focused via the keyboard.

---
*PR created automatically by Jules for task [270052690429874113](https://jules.google.com/task/270052690429874113) started by @Pranav322*