### PR TITLE
🎨 Palette: Make custom file upload keyboard accessible

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - File Upload Keyboard Accessibility
+
+**Learning:** Using Tailwind's `hidden` class on custom `<input type="file">` elements removes them entirely from the accessibility tree and keyboard tab order.
+**Action:** Always use `sr-only` on the hidden input and apply `focus-within` styles (e.g., `focus-within:ring-2`) to its wrapping `<label>` to maintain keyboard accessibility and visual focus states.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-white/50 focus-within:outline-none">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What: Replaced the `hidden` class on the wallpaper upload input with `sr-only` and added `focus-within` ring styles to its wrapping label.
🎯 Why: Using `hidden` completely removes the input from the browser's accessibility tree, preventing keyboard users from tabbing to it or interacting with it.
📸 Before/After: Visuals remain unchanged for mouse users, but keyboard users now see a focus ring when tabbing to the upload button.
♿ Accessibility: The file upload button is now included in the natural tab order and has a clear visual focus indicator, improving keyboard navigability.

---
*PR created automatically by Jules for task [17526420435041591623](https://jules.google.com/task/17526420435041591623) started by @Pranav322*