### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent redundant requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-12 - [Promise Caching for Concurrent Requests]
+
+**Learning:** In Next.js, when multiple components on the same page (e.g. Spotify Window with NowPlaying, TopTracks, TopArtists) concurrently hit different backend API routes that all fetch an access token from an external service, simply caching the token value is insufficient. All initial concurrent requests will see an empty cache and simultaneously trigger a token fetch.
+**Action:** Always cache the `Promise` of the fetch request itself rather than just the final result, and reset the cache validation state (e.g., `tokenExpirationTime = 0`) immediately when a refresh is initiated to ensure concurrent requests properly evaluate the pending state and await the single shared Promise instead of bypassing the cache.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,18 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+  if (cachedTokenPromise && tokenExpirationTime > now) {
+    return cachedTokenPromise;
+  }
+
+  tokenExpirationTime = 0; // Reset to prevent bypass
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +29,23 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        cachedTokenPromise = null;
+        throw new Error('Failed to fetch Spotify access token');
+      }
+      const data = await response.json();
+      // typically expires_in is 3600 (seconds) -> ms
+      tokenExpirationTime = now + (data.expires_in || 3600) * 1000 - 60000; // buffer of 1 min
+      return data;
+    })
+    .catch(error => {
+      cachedTokenPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented Promise-level in-memory caching for Spotify access tokens.
🎯 Why: Resolves duplicate simultaneous Spotify API token requests from concurrent component data fetching.
📊 Impact: Reduces redundant token requests per user session, speeding up the Spotify stats window load time.
🔬 Measurement: Verify by checking network/server logs for a single `/api/token` call when opening the Spotify window.

---
*PR created automatically by Jules for task [12749221998643450515](https://jules.google.com/task/12749221998643450515) started by @Pranav322*