### PR TITLE
🎨 Palette: Fix file input accessibility in SettingsWindow

### DIFF
--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-white/50">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,7 @@
+💡 What: Replaced the Tailwind `hidden` class with `sr-only` on the custom wallpaper file input and added a `focus-within` visual ring to the surrounding `<label>`.
+
+🎯 Why: The `hidden` utility removes elements from the accessibility tree entirely, meaning keyboard users cannot tab to the input, and screen readers cannot interact with it.
+
+📸 Before/After: Visual changes are limited to a focus ring appearing on the upload zone when navigated via keyboard.
+
+♿ Accessibility: The file input is now fully focusable via keyboard navigation, properly read by screen readers, and displays a clear visual focus state on its interactive wrapper label.


### PR DESCRIPTION
💡 What: Replaced the Tailwind `hidden` class with `sr-only` on the custom wallpaper file input and added a `focus-within` visual ring to the surrounding `<label>`.

🎯 Why: The `hidden` utility removes elements from the accessibility tree entirely, meaning keyboard users cannot tab to the input, and screen readers cannot interact with it.

📸 Before/After: Visual changes are limited to a focus ring appearing on the upload zone when navigated via keyboard.

♿ Accessibility: The file input is now fully focusable via keyboard navigation, properly read by screen readers, and displays a clear visual focus state on its interactive wrapper label.

---
*PR created automatically by Jules for task [11390020593311154737](https://jules.google.com/task/11390020593311154737) started by @Pranav322*