### PR TITLE
⚡ Bolt: Cache Spotify access token fetches

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2025-02-12 - [In-Memory Cache for Pending Promises]
+**Learning:** When implementing an in-memory cache for a pending Promise that also tracks expiration time, the cache validation logic must explicitly check the initial pending state (e.g., `tokenExpirationTime === 0`). Otherwise, concurrent requests evaluating `tokenExpirationTime > Date.now()` will find it false (0 > now) and inadvertently bypass the cache while the first request is still resolving, defeating the purpose of the cache for concurrent loads.
+**Action:** Always reset the tracking variable (e.g., `tokenExpirationTime = 0`) before initiating the new fetch and include `tokenExpirationTime === 0` in the cache hit condition.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,17 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let tokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+  if (tokenPromise && (tokenExpirationTime === 0 || tokenExpirationTime > now)) {
+    return tokenPromise;
+  }
+
+  tokenExpirationTime = 0;
+  tokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +28,21 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
+  }).then(async (response) => {
+    if (!response.ok) {
+      tokenPromise = null;
+      throw new Error('Failed to fetch Spotify access token');
+    }
+    const data = await response.json();
+    // Cache for data.expires_in seconds minus a 5-minute (300s) buffer
+    tokenExpirationTime = Date.now() + (data.expires_in - 300) * 1000;
+    return data;
+  }).catch((error) => {
+    tokenPromise = null;
+    throw error;
   });
 
-  return response.json();
+  return tokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented Promise-based in-memory caching for Spotify `getAccessToken()` with expiration tracking and concurrent request handling.
🎯 Why: Multiple components fetch from Spotify APIs on load, triggering multiple concurrent `getAccessToken()` requests which causes network overhead and risks rate limits.
📊 Impact: Reduces Spotify token fetches to exactly 1 request per hour per server instance, saving network overhead.
🔬 Measurement: Check the network logs on server startup and note that only one token request is made even when multiple Spotify endpoints are hit concurrently.

---
*PR created automatically by Jules for task [4609950279310738551](https://jules.google.com/task/4609950279310738551) started by @Pranav322*