### PR TITLE
🎨 Palette: Terminal Controls and Input Accessibility

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Terminal Control Buttons Accessibility
+
+**Learning:** Terminal headers often mimic OS window controls using colored div elements, missing semantics, keyboard focus visibility, and ARIA labels.
+**Action:** Always use semantic <button> elements for window controls and provide proper aria-label and focus-visible styles.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -475,12 +475,25 @@ const Terminalcomp = () => {
       <div className="border-2 border-neutral-800 dark:border-neutral-700 rounded-sm w-full max-w-[700px] h-[500px] max-h-[80vh] bg-black/90 backdrop-blur-sm p-2 sm:p-4 overflow-y-auto font-mono terminal-glow mobile-hide-scrollbar custom-scrollbar">
         <div className="flex justify-between mb-3 sm:mb-5 items-center sticky top-0 bg-black/90 z-20 backdrop-blur-lg p-1 sm:p-2 rounded-sm">
           <div className="flex gap-1 sm:gap-2">
-            <div
-              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-red-500 rounded-full hover:bg-red-400"
+            <button
+              type="button"
+              aria-label="Close terminal"
+              title="Close terminal"
+              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-red-500 rounded-full hover:bg-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
               onClick={() => (window.location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')}
-            ></div>
-            <div className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-yellow-500 rounded-full hover:bg-yellow-400"></div>
-            <div className="w-2 h-2 sm:w-3 sm:h-3 cursor-pointer duration-200 bg-green-500 rounded-full hover:bg-green-400"></div>
+            ></button>
+            <button
+              type="button"
+              aria-label="Minimize terminal"
+              title="Minimize terminal"
+              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-yellow-500 rounded-full hover:bg-yellow-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+            ></button>
+            <button
+              type="button"
+              aria-label="Maximize terminal"
+              title="Maximize terminal"
+              className="w-2 h-2 sm:w-3 sm:h-3 cursor-pointer duration-200 bg-green-500 rounded-full hover:bg-green-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+            ></button>
           </div>
           <h1 className="text-white text-xs sm:text-sm truncate mx-2">{getPrompt()}</h1>
           <span className="flex gap-1 text-xs sm:text-sm border border-white/20 rounded-sm px-1 sm:px-2 py-0.5 sm:py-1 text-green-400">
@@ -525,6 +538,7 @@ const Terminalcomp = () => {
                 className="bg-transparent w-full outline-none border-none focus:outline-none text-white caret-green-500 text-xs sm:text-sm"
                 spellCheck={false}
                 autoFocus
+                aria-label="Terminal command input"
               />
             </form>
           </div>


### PR DESCRIPTION
💡 What:
Replaced decorative `div` elements for terminal window controls with semantic `<button>` tags, adding `aria-label`, `title`, and `focus-visible` classes. Also added an `aria-label` to the terminal command input. Logged this critical UX learning to the `.Jules/palette.md` journal.

🎯 Why:
The terminal window controls were completely invisible to screen readers and lacked keyboard focus indicators, making them inaccessible. The terminal input also lacked a descriptive name. These changes ensure proper keyboard navigation and screen reader support without changing the visual design.

📸 Before/After:
Before: Window controls were `div` elements without focus states or ARIA labels.
After: Window controls are semantic `<button>` elements with `focus-visible:ring-2`, `title`, and `aria-label` attributes. The command input now has an `aria-label`.

♿ Accessibility:
- Added `aria-label` and `title` to the red (Close), yellow (Minimize), and green (Maximize) terminal buttons.
- Added `focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:outline-none` to terminal buttons for clear keyboard focus indication.
- Converted non-semantic `div` elements to `<button type="button">`.
- Added `aria-label="Terminal command input"` to the main terminal text input.

---
*PR created automatically by Jules for task [17492166475990065512](https://jules.google.com/task/17492166475990065512) started by @Pranav322*