### PR TITLE
⚡ Bolt: Cache Spotify access token

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2024-05-14 - Caching Spotify Access Tokens
+**Learning:** When fetching Spotify access tokens in multiple concurrent API routes (e.g., Now Playing, Top Tracks, Playlists), the app makes redundant requests to the token endpoint. The cache validation logic must evaluate the initial pending state (`tokenExpirationTime === 0`) to prevent concurrent requests from bypassing the cache while the first is resolving. Also need to ensure `!response.ok` checks are done to avoid silently caching failed responses.
+**Action:** Implemented an in-memory Promise cache for `getAccessToken()` that stores the pending promise and validates the fetch response.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,17 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let cachedTokenPromise: Promise<{ access_token: string }> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || Date.now() < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +28,26 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch Spotify access token: ${response.status} ${response.statusText}`
+        );
+      }
+      const data = await response.json();
+      // Cache for 1 minute less than actual expiry to be safe
+      const expiresInMs = (data.expires_in - 60) * 1000;
+      tokenExpirationTime = Date.now() + expiresInMs;
+      return data;
+    })
+    .catch(error => {
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implement an in-memory Promise cache for `getAccessToken()` in `lib/spotify.ts` with robust error handling.
🎯 Why: To prevent redundant requests to the Spotify token endpoint when multiple components fetch data simultaneously, which caused API rate limits and slow initial dashboard loads.
📊 Impact: Reduces Spotify token API requests from multiple down to exactly one on initial dashboard load.
🔬 Measurement: Check network logs to verify the token endpoint is hit only once despite multiple widget renders, and that transient network errors clear the cache so it can correctly retry.

---
*PR created automatically by Jules for task [15977998094239602632](https://jules.google.com/task/15977998094239602632) started by @Pranav322*