### PR TITLE
🎨 Palette: Make custom file upload keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Custom File Upload Keyboard Accessibility
+**Learning:** Using 'hidden' on a custom <input type="file"> completely removes it from the accessibility tree and keyboard tab order, preventing users who rely on keyboard navigation from selecting files.
+**Action:** Always use 'sr-only' on the hidden input and apply 'focus-within' utility classes (e.g., 'focus-within:ring-2') to the visible wrapping <label> to maintain keyboard accessibility and visual focus states.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-white/50 focus-within:outline-none">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What: Replaced the 'hidden' class with 'sr-only' on the custom file input in SettingsWindow, and added 'focus-within' styling to its wrapping label.

🎯 Why: Using 'hidden' removes elements from the accessibility tree. This prevented users who rely on keyboard navigation from interacting with the file upload. 

📸 Before/After: Visual focus state is now present when tabbing to the input.

♿ Accessibility: Ensures the custom file upload is fully keyboard accessible while maintaining its visual design.

---
*PR created automatically by Jules for task [13229559769249871138](https://jules.google.com/task/13229559769249871138) started by @Pranav322*