### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent redundant concurrent API requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-05-16 - [Promise Caching for Concurrent Render Requests]
+
+**Learning:** In Next.js/React, when multiple components that rely on the same API data (like various Spotify widgets) render simultaneously, they can trigger redundant concurrent fetch requests if the token or data isn't cached properly. Caching just the resolved token isn't enough; you must cache the `Promise` of the fetch request so concurrent calls await the same pending network request.
+**Action:** When implementing in-memory caches for data used across multiple components, always cache the Promise itself. Ensure the cache correctly handles errors by explicitly clearing the cached Promise in a `.catch()` block to prevent permanently poisoning the cache with failed network requests.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,21 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+import type { Track } from '@/types/spotify';
+
+let cachedPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  if (cachedPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedPromise;
+  }
+
+  tokenExpirationTime = 0;
+
+  cachedPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +32,22 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token`);
+      }
+      const data = await response.json();
+      tokenExpirationTime = Date.now() + (data.expires_in || 3600) * 1000 - 60000; // 60s buffer
+      return data;
+    })
+    .catch(error => {
+      cachedPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implementing an in-memory Promise cache for `getAccessToken()`.
🎯 Why: Multiple Spotify API components render simultaneously on the frontend, triggering redundant token fetch requests due to the lack of a shared cache.
📊 Impact: Reduces Spotify token endpoint calls from N (number of active Spotify components) to 1 per hour, improving API route latency.
🔬 Measurement: Verify fewer duplicate POST requests to Spotify token endpoint in backend server logs when loading the portfolio.

---
*PR created automatically by Jules for task [8077667604454072618](https://jules.google.com/task/8077667604454072618) started by @Pranav322*