### PR TITLE
⚡ Bolt: Cache Spotify access token promise to prevent duplicate concurrent network requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2026-05-17 - [Cache Promise Instead of Resolved Token]
+**Learning:** When components concurrently call multiple endpoints (e.g., top tracks, top artists, recently played), caching the resolved token is insufficient because the first request is still pending while the others fire, leading to duplicate `/api/token` requests and potential rate limiting.
+**Action:** Cache the `Promise` of the fetch request and check for a pending state (e.g., `tokenExpirationTime === 0`) to ensure concurrent requests await the same promise. Also, explicitly handle `.catch()` to clear the cache if the promise rejects.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,16 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || Date.now() < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  tokenExpirationTime = 0;
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +27,22 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Spotify token: ${response.status}`);
+      }
+      const data = await response.json();
+      tokenExpirationTime = Date.now() + (data.expires_in - 300) * 1000;
+      return data;
+    })
+    .catch((error) => {
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for the Spotify access token.
🎯 Why: The previous implementation fetched a new access token on every Spotify API call. When components concurrently call multiple endpoints (e.g., top tracks, top artists, recently played), it generated redundant network requests and could trigger rate-limiting.
📊 Impact: Reduces Spotify token endpoint requests by caching the promise (preventing race conditions) and reusing the valid token across concurrent renders for up to 55 minutes.
🔬 Measurement: Check the network tab or console logs when loading multiple Spotify components; only one `/api/token` request should fire until expiration.

---
*PR created automatically by Jules for task [12781303924063483696](https://jules.google.com/task/12781303924063483696) started by @Pranav322*