### PR TITLE
🎨 Palette: Improve file upload keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-05-17 - File Upload Accessibility
+
+**Learning:** Using Tailwind's `hidden` class on custom file upload inputs removes them from the accessibility tree and keyboard tab order, breaking accessibility.
+**Action:** Always use `sr-only` on the hidden `<input type="file">` and apply `focus-within` utility classes to the wrapping `<label>` to maintain keyboard accessibility and visual focus states.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-white/50 focus-within:outline-none">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What: Changed the file upload input from `hidden` to `sr-only` and added `focus-within` styles to its label.
🎯 Why: Tailwind's `hidden` class removes the element from the accessibility tree and tab order, preventing keyboard users from interacting with the file input.
📸 Before/After: [N/A - visual focus state only]
♿ Accessibility: Allows keyboard users to tab to the file input and see a clear focus ring, restoring full keyboard operability for custom wallpaper uploads.

---
*PR created automatically by Jules for task [9783904636410465013](https://jules.google.com/task/9783904636410465013) started by @Pranav322*