### PR TITLE
🎨 Palette: Fix accessibility of custom file upload input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -6,3 +6,7 @@
 ## 2025-02-23 - Tooltips for Keyboard Focus
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2026-05-18 - File Input Accessibility
+**Learning:** Tailwind's `hidden` class removes file inputs from the accessibility tree, making them completely inaccessible to keyboard and screen reader users.
+**Action:** Use `sr-only` on the `<input type="file">` to keep it in the DOM for screen readers and tab navigation, and apply `focus-within` styles to its visible wrapping `<label>` to display focus states to sighted keyboard users.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-white/50">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 **What:**
Replaced Tailwind's `hidden` class with `sr-only` on the `<input type="file">` in the Settings Window's wallpaper uploader. Added `focus-within:ring-2 focus-within:ring-white/50` to the wrapping `<label>`.

🎯 **Why:**
The `hidden` class applies `display: none`, completely removing the file input from the accessibility tree. This made it impossible for screen reader users or keyboard-only users to focus, upload, or interact with the custom wallpaper upload field. By using `sr-only`, the input remains visually hidden but fully keyboard focusable and accessible to assistive technologies. The `focus-within` styling on the label ensures sighted keyboard users see a clear visual focus ring when tabbing onto the file input.

📸 **Before/After:**
Before: The file input was completely unreachable via keyboard navigation.
After: The file input is now reachable via keyboard (Tab) and displays a clear focus ring on the 'Choose a file or drag it here' box.

♿ **Accessibility:**
- Restored keyboard tab navigation to the custom file uploader.
- Restored screen reader access to the custom file uploader.
- Added visible focus indicators for sighted keyboard users.

---
*PR created automatically by Jules for task [2176455742376978996](https://jules.google.com/task/2176455742376978996) started by @Pranav322*