### PR TITLE
⚡ Bolt: Cache Spotify access token promise

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-05-19 - [Promise Caching for Concurrent API Requests]
+
+**Learning:** Multiple components loaded concurrently (like in SpotifyWindow) that rely on independent API routes calling the same external API will trigger duplicate token generation requests if the token fetch is not cached as a pending Promise.
+**Action:** Always cache the Promise of asynchronous API tokens rather than just the resolved value, and track expiration properly, to prevent multiple simultaneous requests from bypassing the cache.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,17 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || Date.now() < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  tokenExpirationTime = 0; // Reset to indicate pending fetch
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +28,21 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Spotify token fetch failed: ${response.status} ${response.statusText}`);
+      }
+      const data = await response.json();
+      tokenExpirationTime = Date.now() + data.expires_in * 1000 - 60000; // 1 min buffer
+      return data;
+    })
+    .catch(error => {
+      cachedTokenPromise = null; // Reset cache on error
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What:
Implemented an in-memory cache for the Spotify access token that caches the *Promise* of the fetch request rather than just the resolved token value.

🎯 Why:
Multiple components loaded concurrently (like in `SpotifyWindow`) rely on independent API routes that all call `getAccessToken()`. Previously, this would trigger duplicate, concurrent token generation requests to the Spotify API because the cache wasn't tracking the pending state of the fetch.

📊 Impact:
Reduces duplicate token fetch requests from the Spotify API when multiple components render simultaneously.

🔬 Measurement:
Open the `SpotifyWindow` application. Check the network tab or server console logs and verify that there is only one `POST` request to `accounts.spotify.com/api/token` when all the Spotify sub-components (`NowPlaying`, `TopTracks`, `TopArtists`, etc.) mount and request data simultaneously.

---
*PR created automatically by Jules for task [2263731841807717138](https://jules.google.com/task/2263731841807717138) started by @Pranav322*