### PR TITLE
🎨 Palette: Accessible custom file upload

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Accessible Custom File Inputs
+
+**Learning:** Using Tailwind's `hidden` class on custom `<input type="file">` elements removes them from the accessibility tree and keyboard tab order, preventing keyboard users from uploading files.
+**Action:** Always use `sr-only` on the input to hide it visually while preserving keyboard access, and apply `focus-within` utility classes to the wrapping `<label>` to ensure visible focus states.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-blue-500">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>

--- a/pr_desc.txt
+++ b/pr_desc.txt
@@ -1,0 +1,4 @@
+💡 What: Changed the custom file upload input from 'hidden' to 'sr-only' and added focus-within styles.
+🎯 Why: To maintain keyboard tab order and ensure keyboard users can interact with the file upload and see their focus position.
+📸 Before/After: Before: File input was fully removed from accessibility tree. After: Input is visually hidden but navigable, wrapping label shows focus rings.
+♿ Accessibility: Improved keyboard navigation and focus visibility for the wallpaper settings file upload.


### PR DESCRIPTION
💡 What: Changed the custom file upload input from 'hidden' to 'sr-only' and added focus-within styles.
🎯 Why: To maintain keyboard tab order and ensure keyboard users can interact with the file upload and see their focus position.
📸 Before/After: Before: File input was fully removed from accessibility tree. After: Input is visually hidden but navigable, wrapping label shows focus rings.
♿ Accessibility: Improved keyboard navigation and focus visibility for the wallpaper settings file upload.

---
*PR created automatically by Jules for task [12080712351122916785](https://jules.google.com/task/12080712351122916785) started by @Pranav322*