### PR TITLE
⚡ Bolt: Cache Spotify access token Promise to prevent redundant network requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-05-20 - [Promise Caching for Auth Tokens]
+
+**Learning:** When multiple components fetch data from a third-party API concurrently, failing to cache the _Promise_ of the access token leads to duplicate network requests and potential rate limiting.
+**Action:** Always implement an in-memory Promise cache (with proper error handling and expiration reset) for authentication tokens to ensure concurrent requests await the same resolving Promise.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,20 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let cachedPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  if (cachedPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedPromise;
+  }
+
+  // Reset expiration time so concurrent requests wait on the new Promise
+  tokenExpirationTime = 0;
+
+  cachedPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +31,23 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token: ${response.status}`);
+      }
+      const data = await response.json();
+      // Cache for expires_in seconds minus a 5-minute (300s) buffer
+      tokenExpirationTime = Date.now() + (data.expires_in - 300) * 1000;
+      return data;
+    })
+    .catch(error => {
+      cachedPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache with TTL expiration for the Spotify access token fetch request in `getAccessToken()`. It handles pending promises correctly and clears cache immediately on fetch failures.

🎯 Why: In a Next.js server context, rendering multiple Spotify components (e.g., Top Tracks, Top Artists, Now Playing) concurrently would trigger redundant simultaneous token requests because the basic token cache had no concept of an in-flight Promise state. This could lead to rate limiting and slower response times.

📊 Impact: Reduces redundant authentication requests to the Spotify API down to exactly 1 request per component tree render, completely eliminating duplicate network overhead.

🔬 Measurement: Check the Next.js server logs for outbound requests. You will notice only a single token request goes out even if multiple API endpoints (like `getNowPlaying` and `getTopTracks`) are hit simultaneously.

---
*PR created automatically by Jules for task [16489853440279786226](https://jules.google.com/task/16489853440279786226) started by @Pranav322*