### PR TITLE
🎨 Palette: Make terminal window controls accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Semantic Custom Window Controls
+
+**Learning:** Decorative mock-OS window controls (like the red/yellow/green Mac dots) are often implemented using non-semantic `div`s. While visually accurate, this removes them from the tab order and leaves screen reader users without context for interactive elements.
+**Action:** When implementing custom OS-like window decorations, always use semantic `<button>` tags with clear `aria-label`s, `title` attributes (for hover tooltips), and `focus-visible` classes, even if the elements are purely decorative or have minimal functionality.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -475,12 +475,25 @@ const Terminalcomp = () => {
       <div className="border-2 border-neutral-800 dark:border-neutral-700 rounded-sm w-full max-w-[700px] h-[500px] max-h-[80vh] bg-black/90 backdrop-blur-sm p-2 sm:p-4 overflow-y-auto font-mono terminal-glow mobile-hide-scrollbar custom-scrollbar">
         <div className="flex justify-between mb-3 sm:mb-5 items-center sticky top-0 bg-black/90 z-20 backdrop-blur-lg p-1 sm:p-2 rounded-sm">
           <div className="flex gap-1 sm:gap-2">
-            <div
-              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-red-500 rounded-full hover:bg-red-400"
+            <button
+              aria-label="Close Terminal"
+              title="Close"
+              type="button"
+              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-red-500 rounded-full hover:bg-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
               onClick={() => (window.location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')}
-            ></div>
-            <div className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-yellow-500 rounded-full hover:bg-yellow-400"></div>
-            <div className="w-2 h-2 sm:w-3 sm:h-3 cursor-pointer duration-200 bg-green-500 rounded-full hover:bg-green-400"></div>
+            ></button>
+            <button
+              aria-label="Minimize Terminal"
+              title="Minimize"
+              type="button"
+              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-yellow-500 rounded-full hover:bg-yellow-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+            ></button>
+            <button
+              aria-label="Maximize Terminal"
+              title="Maximize"
+              type="button"
+              className="w-2 h-2 sm:w-3 sm:h-3 cursor-pointer duration-200 bg-green-500 rounded-full hover:bg-green-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+            ></button>
           </div>
           <h1 className="text-white text-xs sm:text-sm truncate mx-2">{getPrompt()}</h1>
           <span className="flex gap-1 text-xs sm:text-sm border border-white/20 rounded-sm px-1 sm:px-2 py-0.5 sm:py-1 text-green-400">


### PR DESCRIPTION
💡 What:
Converted the purely decorative `<div>` window controls in the Terminal component (red, yellow, green circles) into semantic `<button>` elements equipped with `aria-label`, `title`, and explicit keyboard `focus-visible` styles.

🎯 Why:
Decorative controls that mimic OS behavior but lack semantic meaning are invisible to screen readers and inaccessible via keyboard navigation. By transforming them into actual buttons, we provide context for screen reader users and ensure keyboard navigability, aligning with the project's inclusive UX philosophy.

📸 Before/After:
Before: The red/yellow/green dots were raw `<div>` tags with `onClick` handlers but no keyboard focus handling or semantic meaning.
After: The dots are `<button type="button">` with focus rings when tabbed to, tooltips on hover, and clear screen-reader labels.

♿ Accessibility:
- Added `aria-label`s for screen reader context ("Close Terminal", "Minimize Terminal", "Maximize Terminal").
- Added `focus-visible:ring-2 focus-visible:ring-white/50` to enable clear visual outlines during keyboard tabbing.
- Changed base element to semantic `<button>`.

---
*PR created automatically by Jules for task [12153102027582696365](https://jules.google.com/task/12153102027582696365) started by @Pranav322*