### PR TITLE
⚡ Bolt: Promise caching for Spotify token endpoint

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2024-05-18 - Promise Caching for Duplicate Network Requests
+
+**Learning:** Caching the Promise of the fetch request (and accurately handling pending state and network failures) is critical for endpoints accessed by multiple components to prevent duplicate concurrent requests.
+**Action:** Implement Promise caching to track the pending state when multiple functions request data simultaneously.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,22 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// Cache the promise itself to prevent concurrent requests during the pending state
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it exists and hasn't expired (or is still pending)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration to 0 to indicate a pending state for concurrent callers
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +33,23 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Spotify token fetch failed: ${response.status} ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Set expiration time with a 60-second buffer
+      tokenExpirationTime = Date.now() + data.expires_in * 1000 - 60000;
+      return data;
+    })
+    .catch(error => {
+      // Clear the cache on error to avoid permanently caching a rejected promise
+      cachedTokenPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Caches the Promise of the Spotify access token fetch request.
🎯 Why: Prevents multiple concurrent requests to the Spotify token endpoint when multiple components require an access token simultaneously.
📊 Impact: Reduces redundant network calls to the Spotify API, decreasing the risk of rate limiting and speeding up API route responses.
🔬 Measurement: Monitor network requests to `https://accounts.spotify.com/api/token` and observe that concurrent requests share the same promise.

---
*PR created automatically by Jules for task [12032897109911752280](https://jules.google.com/task/12032897109911752280) started by @Pranav322*