### PR TITLE
🎨 Palette: Improve keyboard accessibility for custom wallpaper upload

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-05-21 - Accessible Custom File Uploads
+
+**Learning:** Using Tailwind's `hidden` class on `<input type="file">` completely removes it from the accessibility tree and breaks keyboard tab navigation.
+**Action:** Always use `sr-only` on the hidden input and apply `focus-within:ring-2` (and similar focus styles) to the parent `<label>` wrapper so keyboard users receive visual focus indicators.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
* **💡 What:** Replaced `hidden` with `sr-only` on the custom wallpaper file input and added `focus-within` styles to its label wrapper. Added documentation to `.Jules/palette.md`.
* **🎯 Why:** Users navigating by keyboard couldn't tab to or see focus on the wallpaper upload button because `hidden` removed it from the tab order and accessibility tree.
* **📸 Before/After:** (No screenshot, purely functional/a11y change on focus, verified via Playwright)
* **♿ Accessibility:** Restored keyboard tab navigation and added a clear visible focus ring when focused.

---
*PR created automatically by Jules for task [18069826546809690429](https://jules.google.com/task/18069826546809690429) started by @Pranav322*