### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent redundant API requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2024-05-19 - Caching Asynchronous API Tokens
+
+**Learning:** When caching asynchronous API tokens (like the Spotify access token), cache the `Promise` of the fetch request rather than just the resolved token. This prevents duplicate concurrent network requests to the endpoint when multiple components that rely on the data render simultaneously.
+**Action:** Implement in-memory caching for API token requests by caching the promise, correctly evaluating `tokenExpirationTime === 0` for pending state, and explicitly resetting `cachedTokenPromise = null` on error.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,23 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt Optimization: Cache the Spotify access token promise in-memory.
+// This prevents redundant API requests when multiple components (NowPlaying, TopTracks, etc.)
+// load simultaneously and attempt to fetch the token at the same time.
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+  // Return the cached promise if it exists and hasn't expired (or is pending, indicated by 0)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || tokenExpirationTime > now)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration time to 0 to indicate the promise is pending
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +34,25 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token: ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Cache token for slightly less than its actual expiration (usually 3600s) to be safe
+      const expiresInMs = (data.expires_in || 3600) * 1000 - 60000;
+      tokenExpirationTime = Date.now() + expiresInMs;
+      return data;
+    })
+    .catch(error => {
+      // Clear cache on error so we don't indefinitely cache a failed promise
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Caching the Spotify API access token promise in-memory.
🎯 Why: Prevents redundant token fetching when multiple components request Spotify data simultaneously.
📊 Impact: Significantly reduces Spotify API requests and avoids hitting rate limits.
🔬 Measurement: Observe network requests in development or reduced API consumption in Spotify developer dashboard.

---
*PR created automatically by Jules for task [16777173200571301064](https://jules.google.com/task/16777173200571301064) started by @Pranav322*