### PR TITLE
🎨 Palette: Make wallpaper upload keyboard accessible

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Accessible Custom File Uploads
+
+**Learning:** Styling custom file upload inputs (`<input type="file">`) with Tailwind's `hidden` class completely removes them from the accessibility tree and keyboard tab order.
+**Action:** Never use `hidden` for custom file inputs. Instead, use `sr-only` on the input and apply `focus-within` utility classes (e.g., `focus-within:ring-2`) to the wrapping `<label>` to maintain keyboard accessibility and visual focus states.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-white/50 focus-within:outline-none transition-all">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What: Replaced the `hidden` class on the custom wallpaper file input with `sr-only` and added `focus-within` ring styles to its parent label.

🎯 Why: Using `hidden` removed the input from the keyboard tab sequence, preventing keyboard-only users from uploading custom wallpapers.

📸 Before/After: Visual change only visible on keyboard focus (added focus ring).

♿ Accessibility: Restored keyboard tab navigation to the file input and provided a clear visual focus indicator on the custom label.

---
*PR created automatically by Jules for task [16403317194993390410](https://jules.google.com/task/16403317194993390410) started by @Pranav322*