### PR TITLE
🎨 Palette: Make custom file upload accessible in Settings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Custom File Upload Keyboard Accessibility
+
+**Learning:** Using Tailwind's `hidden` class on `<input type="file">` completely removes the element from the accessibility tree and keyboard tab order, making custom file upload buttons inaccessible via keyboard.
+**Action:** Use `sr-only` on the hidden input to keep it focusable, and apply `focus-within` utility classes (e.g., `focus-within:ring-2`) to the wrapping `<label>` to display the focus outline around the custom button design when navigating via keyboard.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:outline-none">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What: Replaced the `hidden` class with `sr-only` on the `<input type="file">` element in `SettingsWindow.tsx`, and added `focus-within:ring-2 focus-within:outline-none` to its parent `<label>`.

🎯 Why: The custom file upload button was completely inaccessible to keyboard users. Using Tailwind's `hidden` class removes the element from the accessibility tree and keyboard tab order. 

📸 Before/After: Before, keyboard users could not tab to or activate the custom wallpaper upload. After, tabbing focuses the hidden input, and the parent label displays a visible focus outline, making it clear where the focus is and allowing activation via the Enter/Space key.

♿ Accessibility: Ensures custom file inputs remain in the keyboard tab order while applying visual focus indicators to the custom UI element via `focus-within`.

---
*PR created automatically by Jules for task [5605065869103397515](https://jules.google.com/task/5605065869103397515) started by @Pranav322*