### PR TITLE
⚡ Bolt: Cache Spotify access token Promise to prevent duplicate concurrent API requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-05-24 - [Promise Caching for Concurrent Requests]
+
+**Learning:** When multiple components fetch data simultaneously on mount (e.g., Spotify components calling `getAccessToken`), they can trigger N+1 identical requests if only the result is cached. Caching the `Promise` of the network request itself prevents these duplicate network calls while the first request is still pending.
+**Action:** Always cache the `Promise` rather than just the resolved value when optimizing API calls that may be requested concurrently by multiple components, ensuring you handle rejected promises by clearing the cache.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,24 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// Cache the Promise of the token request to prevent duplicate concurrent API requests
+// when multiple Spotify components render simultaneously (e.g., NowPlaying, TopTracks).
+let cachedTokenPromise: Promise<{ access_token: string; expires_in?: number }> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the pending or resolved Promise if it exists and hasn't expired
+  // (or if it's currently resolving, in which case expirationTime is 0)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration time while pending
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +35,26 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token: ${response.statusText}`);
+      }
+      const data = await response.json();
 
-  return response.json();
+      // Cache the token with a safety margin of 60 seconds before it expires
+      if (data.expires_in) {
+        tokenExpirationTime = now + (data.expires_in - 60) * 1000;
+      }
+      return data;
+    })
+    .catch(error => {
+      // Reset the cache variable on failure so subsequent requests can try again
+      cachedTokenPromise = null;
+      throw error;
+    });
+
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented Promise caching for the Spotify API access token (`getAccessToken` in `lib/spotify.ts`). Instead of just caching the resolved token, it caches the pending `Promise` itself and correctly handles error states and expiration logic.

🎯 Why: To solve a "thundering herd" N+1 problem. When multiple Spotify components (e.g., NowPlaying, TopTracks, TopArtists) render simultaneously on mount, they all try to fetch their respective data. Since each endpoint requires an access token, they were all triggering `getAccessToken` concurrently before the first request could resolve and cache its result, leading to duplicate network requests to the Spotify Token API.

📊 Impact: Reduces Spotify token generation API requests from ~N (where N is the number of rendered Spotify widgets) down to exactly 1 on initial load or token refresh. This saves bandwidth, speeds up component resolution, and significantly reduces the risk of hitting Spotify's API rate limits.

🔬 Measurement: Verify the improvement by opening the network tab in browser dev tools, clearing the network log, and opening the "My Spotify" window. Observe that only one POST request is made to `accounts.spotify.com/api/token` instead of multiple duplicate requests.

---
*PR created automatically by Jules for task [2041128656069239540](https://jules.google.com/task/2041128656069239540) started by @Pranav322*