### PR TITLE
🎨 Palette: Terminal Window Controls Accessibility Improvement

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - OS Window Control Accessibility
+
+**Learning:** Creating UI elements that mimic OS window controls (like the Mac-style red, yellow, green terminal header dots) with generic `div` elements prevents keyboard navigation and hides their purpose from screen reader users.
+**Action:** Always use semantic `<button>` elements with clear `aria-label`, `title` for hover/focus context, and `focus-visible` utility classes for these interactive window controls, even if they are purely decorative or have minimal functionality.

--- a/app/components/Terminal/Terminal.tsx
+++ b/app/components/Terminal/Terminal.tsx
@@ -475,12 +475,25 @@ const Terminalcomp = () => {
       <div className="border-2 border-neutral-800 dark:border-neutral-700 rounded-sm w-full max-w-[700px] h-[500px] max-h-[80vh] bg-black/90 backdrop-blur-sm p-2 sm:p-4 overflow-y-auto font-mono terminal-glow mobile-hide-scrollbar custom-scrollbar">
         <div className="flex justify-between mb-3 sm:mb-5 items-center sticky top-0 bg-black/90 z-20 backdrop-blur-lg p-1 sm:p-2 rounded-sm">
           <div className="flex gap-1 sm:gap-2">
-            <div
-              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-red-500 rounded-full hover:bg-red-400"
+            <button
+              type="button"
+              aria-label="Close terminal"
+              title="Close terminal"
+              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-red-500 rounded-full hover:bg-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-1 focus-visible:ring-offset-black"
               onClick={() => (window.location.href = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ')}
-            ></div>
-            <div className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-yellow-500 rounded-full hover:bg-yellow-400"></div>
-            <div className="w-2 h-2 sm:w-3 sm:h-3 cursor-pointer duration-200 bg-green-500 rounded-full hover:bg-green-400"></div>
+            ></button>
+            <button
+              type="button"
+              aria-label="Minimize terminal"
+              title="Minimize terminal"
+              className="w-2 h-2 sm:w-3 sm:h-3 duration-200 cursor-pointer bg-yellow-500 rounded-full hover:bg-yellow-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 focus-visible:ring-offset-1 focus-visible:ring-offset-black"
+            ></button>
+            <button
+              type="button"
+              aria-label="Maximize terminal"
+              title="Maximize terminal"
+              className="w-2 h-2 sm:w-3 sm:h-3 cursor-pointer duration-200 bg-green-500 rounded-full hover:bg-green-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-1 focus-visible:ring-offset-black"
+            ></button>
           </div>
           <h1 className="text-white text-xs sm:text-sm truncate mx-2">{getPrompt()}</h1>
           <span className="flex gap-1 text-xs sm:text-sm border border-white/20 rounded-sm px-1 sm:px-2 py-0.5 sm:py-1 text-green-400">


### PR DESCRIPTION
💡 What: Replaced decorative `div` elements used for OS window controls (red, yellow, green dots) in the Terminal header with semantic `<button>` elements.

🎯 Why: The previous implementation used generic `div` tags, meaning these controls were completely invisible to screen readers and impossible to reach via keyboard navigation, violating basic accessibility standards for interactive elements.

📸 Before/After:
Before: `div` tags without ARIA labels or keyboard focus rings.
After: `<button>` tags with hover tooltips and clear keyboard focus rings.

♿ Accessibility: 
- Added semantic `<button>` roles.
- Added `aria-label` attributes ("Close terminal", "Minimize terminal", "Maximize terminal").
- Added `title` attributes to provide context on mouse hover or keyboard focus.
- Added `focus-visible` utility classes to show a clear visual outline when navigating with the keyboard.

---
*PR created automatically by Jules for task [16610556635140577387](https://jules.google.com/task/16610556635140577387) started by @Pranav322*