### PR TITLE
⚡ Bolt: Cache Spotify access token Promise to prevent duplicate network requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2026-05-25 - [In-memory Promise Caching for APIs]
+
+**Learning:** When fetching data used across multiple components concurrently (like Spotify tokens), caching only the resolved token is insufficient and leads to race conditions where multiple pending requests spawn separate network calls. Caching the `Promise` itself prevents these duplicate network requests. Additionally, when using expirations, the cache state needs to accurately reflect the "pending" state (e.g. `expirationTime = 0`) before the promise resolves so concurrent requests don't skip the cache check during the fetch.
+**Action:** When implementing in-memory caches for data fetched simultaneously by multiple components, cache the `Promise` returned by `fetch` rather than the final result, properly resetting the cache in the `.catch()` block to prevent transient failures from poisoning the cache.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,25 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// Cache the Promise of the token fetch to prevent duplicate concurrent network requests.
+// This is critical since multiple components might request Spotify data simultaneously.
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // If we have a pending promise or a valid token, return the cached promise
+  // We check if tokenExpirationTime is 0 to correctly evaluate the initial pending state
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration time before initiating the new fetch to ensure concurrent requests
+  // correctly evaluate the pending state instead of bypassing the cache with a stale expiration.
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +36,25 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      // Explicitly check !response.ok to prevent silently caching failed HTTP responses
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token: ${response.status} ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Set expiration time (subtract 5 minutes (300000ms) as a buffer)
+      tokenExpirationTime = Date.now() + data.expires_in * 1000 - 300000;
+      return data;
+    })
+    .catch(error => {
+      // Reset cache variable to prevent transient errors from poisoning the cache permanently
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory single-flight Promise cache for the `getAccessToken` function in `lib/spotify.ts` with proper expiration logic and error state resetting.
🎯 Why: Multiple components on the frontend (Now Playing, Top Tracks, Top Artists) can mount concurrently, initiating simultaneous requests that previously resulted in duplicate API calls to Spotify's `/api/token` endpoint.
📊 Impact: Reduces redundant network requests for Spotify access tokens during concurrent component mounts. 5 simultaneous component requests now correctly resolve to 1 single token fetch.
🔬 Measurement: Verified caching behavior through temporary `fetch` mock tests confirming concurrent `getNowPlaying()` calls only spawn 1 active network request. All app linters and test suites pass.

---
*PR created automatically by Jules for task [16906143378270219589](https://jules.google.com/task/16906143378270219589) started by @Pranav322*