### PR TITLE
⚡ Bolt: Cache Spotify access token promise to prevent concurrent token requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-05-26 - [Cache API Request Promises for Concurrent Renderings]
+
+**Learning:** When multiple components requiring the same API data (like Spotify tokens) render concurrently, they can trigger duplicate simultaneous fetch requests before the first one resolves. Simply caching the resolved value does not prevent the race condition.
+**Action:** Always cache the _pending Promise_ of the API request alongside an expiration state. This ensures all concurrent callers await the same request rather than spawning duplicates.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,26 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt: Cache Spotify access token promise to prevent concurrent requests
+// 💡 What: Cache the pending fetch Promise and its resolved token, with expiration.
+// 🎯 Why: Multiple components rendering simultaneously (e.g., Now Playing, Top Tracks)
+//        can trigger duplicate token requests before the first one completes.
+//        Caching the Promise ensures all concurrent callers await the same request.
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it's currently fetching (expiration is 0) or the token hasn't expired
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration to indicate a pending request and prevent concurrent fetches
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +37,25 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      // Throw error before parsing to prevent silently caching failed HTTP responses
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token: ${response.statusText}`);
+      }
+      const data = await response.json();
 
-  return response.json();
+      // Set expiration time (subtracting a 60s buffer to ensure token is valid)
+      tokenExpirationTime = now + (data.expires_in - 60) * 1000;
+      return data;
+    })
+    .catch(error => {
+      // Clear the cache promise to avoid poisoning it with a rejection
+      cachedTokenPromise = null;
+      throw error;
+    });
+
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented a Promise-based cache for the Spotify `getAccessToken` function. It caches the pending `fetch` Promise along with an expiration time, ensuring concurrent callers await the same request instead of spawning duplicates.

🎯 Why: In Next.js, multiple Server Components or API routes rendering simultaneously (e.g., Now Playing, Top Tracks, Playlists) all require a valid access token. Previously, this caused multiple redundant `POST` requests to the Spotify API, wasting bandwidth and potentially hitting rate limits.

📊 Impact: Reduces redundant Spotify token requests from N (number of concurrent components) down to 1 during the initial load or token refresh cycle.

🔬 Measurement: Verify by checking network logs (or server console if logged) during a page refresh that triggers multiple Spotify component renders. Only one request to `accounts.spotify.com/api/token` should occur.

---
*PR created automatically by Jules for task [227778732663400730](https://jules.google.com/task/227778732663400730) started by @Pranav322*