### PR TITLE
🎨 Palette: Add accessibility attributes to SpotifyWindow controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-05-26 - Inconsistent Duplicate Component Copies
+
+**Learning:** Window controls (Minimize, Maximize, Close) are often copied-and-pasted across multiple components (e.g., `BrowserWindow.tsx` vs `SpotifyWindow.tsx`). This often leads to inconsistent application of baseline accessibility standards (ARIA labels, keyboard focus styling), creating hidden accessibillity barriers in UI derivatives.
+**Action:** Always verify a11y regressions in duplicate UI patterns, and when encountering multiple identical components lacking accessibility attributes, advocate for refactoring them into a shared, accessible UI component.

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -40,18 +40,27 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
           </div>
           <div className="flex items-center gap-4">
             <button
+              aria-label="Minimize"
+              title="Minimize"
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none rounded-sm"
             >
               <IconMinus size={18} />
             </button>
             <button
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none rounded-sm"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              aria-label="Close"
+              title="Close"
+              onClick={onClose}
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none rounded-sm"
+            >
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
💡 **What:** 
Added missing accessibility attributes (`aria-label`, `title`) and keyboard focus visibility classes (`focus-visible:ring-2`) to the icon-only window controls (Minimize, Maximize, Close) in `SpotifyWindow.tsx`.

🎯 **Why:** 
The window controls lacked programmatic labels, rendering them invisible to screen readers, and lacked focus states, making them untab-able for keyboard users. These updates align the component with the accessibility standards already present in `BrowserWindow.tsx`.

📸 **Before/After:**
- **Before:** Buttons were solely icons, inaccessible via keyboard focus or screen reader.
- **After:** Buttons have descriptive ARIA labels, hover tooltips, and distinct keyboard focus rings.

♿ **Accessibility:**
- Added `aria-label` and `title` to all three control buttons.
- Dynamically toggle Maximize/Restore label based on window state.
- Added `focus-visible:ring-2 focus-visible:outline-none` for explicit keyboard focus indication.

---
*PR created automatically by Jules for task [3814233748556131996](https://jules.google.com/task/3814233748556131996) started by @Pranav322*