### PR TITLE
⚡ Bolt: Cache Spotify Token Promise for Concurrent Requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-05-27 - [Caching Concurrent Promises]
+
+**Learning:** When multiple components request an API simultaneously on mount (e.g., Spotify dashboard components), caching just the final resolved value isn't enough; concurrent requests will still trigger multiple initial network calls.
+**Action:** Cache the Promise itself (`let cachedPromise: Promise<any> | null`) and return it immediately while pending. Also, explicitly manage expiration during the pending state (`tokenExpirationTime = 0`) and attach a `.catch()` handler to reset the cache if the request fails, preventing transient network errors from permanently poisoning the cache.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,23 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// Cache the Promise itself (not just the value) to handle concurrent requests efficiently
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return cached promise if it exists and hasn't expired
+  // Evaluates tokenExpirationTime === 0 to correctly bypass check for pending initial request
+  if (cachedTokenPromise !== null && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration to 0 while pending to prevent concurrent requests from bypassing
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +34,25 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      // Explicitly check response.ok to avoid caching bad responses
+      if (!response.ok) {
+        throw new Error(`Spotify token fetch failed: ${response.status}`);
+      }
+      const data = await response.json();
+      // Cache the token for its expiration duration (usually 3600s), minus 1 minute buffer
+      tokenExpirationTime = Date.now() + (data.expires_in || 3600) * 1000 - 60000;
+      return data;
+    })
+    .catch(error => {
+      // Attach a .catch() block to reset cache on error, preventing transient errors from poisoning
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What:
Implemented an in-memory promise cache for the `getAccessToken()` function in `lib/spotify.ts`. Instead of caching just the final resolved token value, it caches the `fetch` Promise itself and correctly manages the expiration state during the pending resolution phase. It also implements strict error handling (`!response.ok` checks and `.catch()` blocks) to reset the cache if the network request fails.

🎯 Why:
The frontend `SpotifyWindow` loads multiple Spotify endpoints concurrently on mount (`NowPlaying`, `TopTracks`, `TopArtists`, `TopGenres`, `Playlists`, `RecentlyPlayed`). Previously, this caused a cache stampede where all 6 components triggered redundant requests to the Spotify Token API simultaneously because the cache was only populated *after* the first request resolved.

📊 Impact:
Reduces redundant API calls to the Spotify Token endpoint from 6 to 1 on initial load or token expiration, significantly reducing network overhead and preventing potential rate-limiting from Spotify.

🔬 Measurement:
Start the application locally, open the network tab, and click the "My Spotify" icon to mount the components. Observe the network requests: you should see only a single request to the Spotify token endpoint resolving the token for all concurrent data fetch requests.

---
*PR created automatically by Jules for task [6991116954909469613](https://jules.google.com/task/6991116954909469613) started by @Pranav322*