### PR TITLE
🎨 Palette: Add accessible window controls to Experience Window

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-05-28 - Dynamic ARIA Labels for Window Controls
+
+**Learning:** Window controls that change state (like Maximize/Restore) need dynamic aria-label and title attributes that reflect their current state (e.g., isMaximized ? 'Restore' : 'Maximize'), rather than static labels, to provide accurate context to screen readers.
+**Action:** When implementing or updating window control buttons, always bind the aria-label and title to the component's state to ensure accurate accessibility information.

--- a/app/components/windows/ExperienceWindow.tsx
+++ b/app/components/windows/ExperienceWindow.tsx
@@ -73,21 +73,27 @@ export default function ExperienceWindow({ onClose }: ExperienceWindowProps) {
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
💡 What:
Added dynamic `aria-label`, `title`, and `focus-visible` classes to the window control buttons (Minimize, Maximize/Restore, Close) in `ExperienceWindow.tsx`. Added a learning to the palette journal regarding dynamic aria-labels for stateful window controls.

🎯 Why:
Screen reader users and keyboard users lacked context and visual focus indication for window management buttons. The buttons were previously only identifiable by their visual icon and lacked any semantic meaning or focus outline when navigating via keyboard.

📸 Before/After:
Before: `<motion.button className="p-2 rounded-full"> <IconSquare /> </motion.button>` (No focus outline, no screen reader label)
After: Added `focus-visible:ring-2 focus-visible:outline-none` for keyboard focus rings and dynamic tooltips like `aria-label={isMaximized ? 'Restore' : 'Maximize'}`.

♿ Accessibility:
- Implemented dynamic Maximize/Restore labels depending on state.
- Added static Minimize and Close labels to corresponding buttons.
- Added keyboard focus outlines to ensure keyboard navigability.

---
*PR created automatically by Jules for task [12067373674918325111](https://jules.google.com/task/12067373674918325111) started by @Pranav322*