### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent concurrent redundant fetches

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-05-30 - [Spotify Token Caching]
+
+**Learning:** The Spotify API integration was repeatedly calling `getAccessToken()` for every backend route without caching the result. When a window loads multiple Spotify components simultaneously (e.g., playlists, recently played, top tracks), this causes N parallel token requests to the Spotify accounts API.
+**Action:** Always implement an in-memory Promise cache for API access tokens to prevent redundant concurrent fetches and respect rate limits.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,23 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// In-memory cache variables for the Spotify access token
+let cachedTokenPromise: Promise<{ access_token: string; expires_in: number }> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it exists and hasn't expired
+  // tokenExpirationTime === 0 check is needed during the pending state of a refresh
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset to pending state before initiating fetch
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +34,26 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(response => {
+      // Don't cache failed requests
+      if (!response.ok) {
+        throw new Error(`Spotify API error: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then(data => {
+      // Set expiration time to slightly before the actual expiration to provide a buffer
+      tokenExpirationTime = now + data.expires_in * 1000 - 60000;
+      return data;
+    })
+    .catch(error => {
+      // Reset cache on error to prevent permanently poisoning the cache with a rejected promise
+      cachedTokenPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for `getAccessToken()` in `lib/spotify.ts`.
🎯 Why: The Spotify integration components (playlists, recently played, etc.) load simultaneously, causing the backend to fire multiple redundant `getAccessToken()` requests.
📊 Impact: Reduces parallel requests to the Spotify token endpoint from N (number of components) to 1 on initial load, saving latency and avoiding rate limits.
🔬 Measurement: Run the app and check network logs. Only one request to `accounts.spotify.com/api/token` will be made when the Spotify window opens.

---
*PR created automatically by Jules for task [911657942448007377](https://jules.google.com/task/911657942448007377) started by @Pranav322*