### PR TITLE
🎨 Palette: [ProjectsWindow Accessibility]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-05-30 - Window Control Accessibility
+
+**Learning:** Some window components within this application (e.g., ProjectsWindow, AboutWindow, PdfWindow) have window control buttons (minimize, maximize, close) that visually appear interactive but lack semantic accessibility attributes, unlike their counterparts in `BrowserWindow.tsx`. This causes inconsistent screen reader experiences and poor keyboard focus indication. Furthermore, dynamic states like Maximize/Restore need ARIA labels that update accurately.
+**Action:** When implementing or updating custom window controls, ensure all interactive buttons include `aria-label`, `title`, and `focus-visible` utility classes. For toggles (like maximize), dynamically update the `aria-label` to reflect the current state (e.g., `isMaximized ? 'Restore' : 'Maximize'`).

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -44,21 +44,28 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
💡 What: Added semantic accessibility attributes (`aria-label`, `title`, and `focus-visible` utility classes) to the window control buttons (minimize, maximize, close) in the `ProjectsWindow` component. Also wired up the missing `onClick` handler for the minimize button.
🎯 Why: To improve keyboard navigation and provide essential context to screen readers, making the window controls accessible and consistent with baseline standards established in components like `BrowserWindow`.
📸 Before/After: Visuals remain unchanged, but focus states (rings) are now clearly visible when navigating via keyboard. A temporary frontend verification script was run locally.
♿ Accessibility:
- Screen readers now correctly identify the purpose of the window control buttons.
- The 'Maximize' button dynamically updates its ARIA label and title to 'Restore' when maximized.
- Keyboard users now have a clear visual indicator (`focus-visible:ring-2`) of which control currently holds focus.

---
*PR created automatically by Jules for task [2352402162040727059](https://jules.google.com/task/2352402162040727059) started by @Pranav322*