### PR TITLE
⚡ Bolt: Implement in-memory Promise cache for Spotify Access Token

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2026-05-31 - [In-Memory Promise Cache Edge Cases]
+
+**Learning:** When implementing an in-memory Promise cache (like for Spotify Access Tokens), evaluating only `now < expirationTime` is insufficient because it evaluates to `false` for a pending state where `expirationTime = 0`, causing concurrent requests to incorrectly bypass the cache while the first fetch is still in flight. Furthermore, failed responses (e.g., 500 errors) lack expected fields like `expires_in`, so we must explicitly check `!response.ok` and throw before JSON parsing to prevent silently caching bad data. Finally, a `.catch()` block MUST reset the cache variable (e.g., `cachedPromise = null`) before re-throwing, otherwise transient network errors permanently poison the cache with a rejected Promise.
+**Action:** When caching Promises, explicitly reset the tracking variable to a pending state (e.g., `tokenExpirationTime = 0`), explicitly check for this pending state in the cache hit logic (e.g., `tokenExpirationTime === 0 || now < tokenExpirationTime`), check `!response.ok`, and always attach a `.catch()` block to clear the cache on failure.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,25 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt: Implement in-memory Promise cache for Spotify Access Token
+// Prevents redundant concurrent token fetches when multiple components
+// (e.g., DesktopIcons prefetching) request Spotify data simultaneously.
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // If a pending request exists, or we have a valid token, return the cache.
+  // Explicitly checking tokenExpirationTime === 0 handles the pending state.
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset to pending state before initiating new fetch
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +36,24 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Spotify API error: ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Tokens typically expire in 1 hour (3600 seconds). We buffer by 5 minutes.
+      tokenExpirationTime = now + (data.expires_in - 300) * 1000;
+      return data;
+    })
+    .catch(error => {
+      // Prevent failed requests from poisoning the cache
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What:
Implemented an in-memory Promise cache for the `getAccessToken()` function in `lib/spotify.ts`.

🎯 Why:
The application prefetches multiple Spotify components concurrently (e.g., Now Playing, Top Tracks, Top Artists) through Next.js dynamic imports or direct API routes. Previously, each of these concurrent server-side requests would trigger an independent fetch to the Spotify Token API to get a new access token, leading to redundant network calls, slower rendering, and potential API rate-limiting issues.

📊 Impact:
Significantly reduces server-side network overhead and API rate-limiting risk. Concurrent Spotify component renders will now coalesce into a single token fetch, reducing redundant requests by 100% for parallel calls. It also safely buffers expiration by 5 minutes to prevent race conditions during token rotation.

🔬 Measurement:
Verify the improvement by observing server-side network logs or Next.js development server output (`pnpm dev`) when loading the application. Only a single request to `accounts.spotify.com/api/token` will be made when multiple components load simultaneously, whereas previously there would be multiple redundant requests.

---
*PR created automatically by Jules for task [8218071326864333906](https://jules.google.com/task/8218071326864333906) started by @Pranav322*