### PR TITLE
🎨 Palette: Add accessibility attributes to PdfWindow controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Inconsistent Window Control Accessibility
+
+**Learning:** The application uses duplicate implementations of window control buttons across different window components (e.g., PdfWindow, AboutWindow). This leads to inconsistent accessibility, where some windows lack `aria-label`, `title`, and `focus-visible` styles, and even miss functionality like `onClick` for minimize buttons.
+**Action:** When working with duplicated UI patterns like window controls, ensure baseline accessibility attributes (like dynamic `aria-label` for Maximize/Restore states and focus rings) are consistently applied. Future work should consolidate these into a shared, accessible component.

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -39,21 +39,28 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label`, `title` tooltips, `focus-visible` styling, and an `onClick` handler to the window control buttons (Minimize, Maximize, Close) in `PdfWindow.tsx`.

🎯 Why: The window control buttons were icon-only and lacked keyboard/screen-reader context, making them inaccessible.

📸 Before/After: N/A - purely semantic and interactive styling changes.

♿ Accessibility:
- Added dynamic `aria-label` (e.g., 'Restore' vs 'Maximize') for accurate screen reader context.
- Added `title` tooltips for hover context.
- Added `focus-visible:ring-2` to ensure proper visual focus indicators for keyboard navigation.
- Fixed the missing functionality of the minimize button by binding `onClick={handleMinimize}`.

---
*PR created automatically by Jules for task [8640872640763952870](https://jules.google.com/task/8640872640763952870) started by @Pranav322*