### PR TITLE
🎨 Palette: Accessible Window Controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Accessible Window Controls
+
+**Learning:** Custom OS-like window controls built with `motion.button` and icon-only content lack context for screen readers and keyboard users. `focus-visible` states are critical for keyboard navigation, and `aria-label`/`title` attributes for dual-state buttons (like Maximize/Restore) must dynamically update to reflect the current state.
+**Action:** When implementing custom window controls, always add descriptive `aria-label` and `title` attributes (dynamic where necessary), and ensure the buttons have clear `focus-visible:ring-2 focus-visible:outline-none` classes to support keyboard accessibility.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -49,21 +49,28 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -39,21 +39,28 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -127,21 +127,28 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>
@@ -218,7 +225,9 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
               whileTap={{ scale: 0.95 }}
               onClick={sendMessage}
               disabled={isLoading || !input.trim()}
-              className="px-3 sm:px-4 bg-white/5 hover:bg-white/10 disabled:opacity-50 rounded-lg border border-white/10 transition-colors touch-target"
+              aria-label="Send message"
+              title="Send message"
+              className="px-3 sm:px-4 bg-white/5 hover:bg-white/10 disabled:opacity-50 rounded-lg border border-white/10 transition-colors touch-target focus-visible:ring-2 focus-visible:ring-purple-500/50 focus-visible:outline-none"
             >
               <IconSend size={16} className="text-purple-400" />
             </motion.button>

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -53,21 +53,28 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` and `title` attributes (e.g., updating between "Maximize" and "Restore"), `focus-visible:ring-2 focus-visible:outline-none` classes, and missing `onClick` bindings to the window control buttons across four window components. Also added an `aria-label` to the icon-only send button in the chat component.

🎯 Why: Custom OS-like window controls built with `motion.button` and icon-only content lack context for screen readers and are invisible to keyboard users when tabbing through the interface. This ensures all interactive window elements are fully discoverable and usable.

📸 Before/After: Before, keyboard users could tab to the controls but there was no visual focus indicator or screen reader announcement. After, tabbing outlines the buttons with a clear focus ring, and screen readers correctly announce "Minimize", "Maximize/Restore", or "Close" and "Send message". 

♿ Accessibility: Ensures WCAG compliance for interactive elements by providing accessible names (`aria-label`) and visible keyboard focus indicators (`focus-visible`). The dynamic toggle for Maximize/Restore provides accurate state reporting.

---
*PR created automatically by Jules for task [10310125457162807364](https://jules.google.com/task/10310125457162807364) started by @Pranav322*