### PR TITLE
⚡ Bolt: Optimize Spotify API token requests with in-memory Promise cache

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2026-06-03 - Avoid redundant token requests across multiple concurrent API routes
+
+**Learning:** Multiple components simultaneously triggering independent backend API endpoints can cause identical, concurrent authentication fetch requests if not properly cached at the Promise level.
+**Action:** Apply an in-memory Promise cache strategy with proper pending state and failure rejection handling to prevent this issue next time.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,7 +8,10 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
+async function fetchAccessToken() {
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -21,7 +24,30 @@ async function getAccessToken() {
     }),
   });
 
-  return response.json();
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Spotify access token: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  // Set expiration time slightly before the actual expiration to ensure safety
+  tokenExpirationTime = Date.now() + (data.expires_in - 5) * 1000;
+  return data;
+}
+
+// Optimization: In-memory Promise cache to prevent redundant concurrent fetches to the Spotify API
+async function getAccessToken() {
+  const now = Date.now();
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  tokenExpirationTime = 0; // Set to pending state to block concurrent requests
+  cachedTokenPromise = fetchAccessToken().catch(error => {
+    cachedTokenPromise = null;
+    throw error;
+  });
+
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache in `lib/spotify.ts` for the `getAccessToken` function. It caches the pending `fetchAccessToken` promise and returns it to concurrent callers, ensuring the Spotify authentication API is only hit once even when multiple Next.js API endpoints are triggered simultaneously.

🎯 Why: The Spotify window has multiple components (Now Playing, Top Tracks, Playlists, etc.) that load simultaneously. Each component hits a separate Next.js API route (`/api/spotify/now-playing`, etc.), which in turn calls `getAccessToken()`. Because these API calls are concurrent and isolated, they were triggering identical, redundant token refreshes to the Spotify API, leading to a "thundering herd" problem that degrades backend performance and risks rate-limiting.

📊 Impact: Reduces redundant token fetch requests from N to 1 during concurrent load scenarios (where N is the number of simultaneous Spotify UI widgets loading). Reduces serverless execution time and lowers the risk of hitting Spotify API rate limits.

🔬 Measurement: I verified the improvement by creating a mock script that executed multiple backend Spotify functions concurrently (`getTopArtists`, `getTopTracks`, `getPlaylists`, `getNowPlaying`) with `Promise.all()`. Before the optimization, the mocked token endpoint was hit 4 times. After the optimization, the mock was strictly hit 1 time.

---
*PR created automatically by Jules for task [12709818655914366452](https://jules.google.com/task/12709818655914366452) started by @Pranav322*