### PR TITLE
🎨 Palette: Make custom wallpaper upload keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2026-06-03 - File Upload Accessibility
+
+**Learning:** Using Tailwind's `hidden` class on custom `<input type="file">` elements removes them from the accessibility tree and keyboard tab order, breaking keyboard navigation.
+**Action:** When styling custom file upload inputs, always use `sr-only` on the input element instead of `hidden`, and apply `focus-within` utility classes (e.g., `focus-within:ring-2`) to the parent label wrapper to maintain accessibility and visual focus states.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:ring-white/50 focus-within:outline-none">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
💡 What:
Replaced the `hidden` class on the custom wallpaper file input with `sr-only` and added `focus-within:ring-2` to its wrapping label.

🎯 Why:
The `hidden` class (`display: none`) completely removes the input from the browser's accessibility tree and disrupts normal keyboard tab ordering. 

📸 Before/After:
Before: Tabbing through the Settings window would skip the Custom Wallpaper section entirely.
After: Tabbing focuses the file upload area, rendering a visual focus ring so users know they can press Enter/Space to open the file dialog.

♿ Accessibility:
Ensures keyboard-only users can interact with custom wallpaper uploads and are provided with a visible focus state.

---
*PR created automatically by Jules for task [9952973935448209958](https://jules.google.com/task/9952973935448209958) started by @Pranav322*