### PR TITLE
⚡ Bolt: Cache Spotify access tokens

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2025-06-04 - Caching Spotify Access Tokens
+
+**Learning:** Adding an in-memory Promise cache to `getAccessToken` in `lib/spotify.ts` prevents redundant concurrent API requests when multiple components (Now Playing, Top Tracks, Playlists, etc.) request data simultaneously on page load. Crucially, the cache mechanism must attach a `.catch()` block to reset the cache state if the fetch fails, preventing permanent poisoning of the cache, and the check for cache hit must account for the pending state (`tokenExpirationTime === 0`) to correctly return the pending promise.
+**Action:** When implementing in-memory caching for asynchronous fetches to prevent race conditions or concurrent requests, always explicitly track pending states and catch Promise rejections to reset the tracking variables.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,7 +8,11 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
+// Cache variables for Spotify access token to prevent redundant API requests.
+let cachedPromise: Promise<{ access_token: string }> | null = null;
+let tokenExpirationTime: number = -1; // -1 means no cache, 0 means pending request
+
+async function fetchAccessToken() {
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -21,7 +25,37 @@ async function getAccessToken() {
     }),
   });
 
-  return response.json();
+  if (!response.ok) {
+    throw new Error(`Failed to fetch access token: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  // Spotify tokens typically expire in 3600 seconds (1 hour). We subtract 5 minutes (300000ms) for a safe buffer.
+  const expiresIn = data.expires_in ? data.expires_in * 1000 : 3600 * 1000;
+  tokenExpirationTime = Date.now() + expiresIn - 300000;
+  return data;
+}
+
+async function getAccessToken() {
+  const now = Date.now();
+
+  // Return cached promise if it's currently fetching (tokenExpirationTime === 0)
+  // or if the token is still valid.
+  if (cachedPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedPromise;
+  }
+
+  // Set to pending state to prevent concurrent requests from initiating their own fetches
+  tokenExpirationTime = 0;
+
+  // Create a new promise and attach a .catch to clean up on failure
+  cachedPromise = fetchAccessToken().catch(error => {
+    cachedPromise = null;
+    tokenExpirationTime = -1;
+    throw error;
+  });
+
+  return cachedPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for `getAccessToken` in `lib/spotify.ts` with correct state handling, expiration buffering, and error catching.
🎯 Why: Multiple components on the frontend request data simultaneously. Previously, this caused multiple concurrent, redundant roundtrips to the Spotify API just to retrieve the same access token, leading to slower page loads and potential rate limiting.
📊 Impact: Eliminates redundant concurrent fetches to the Spotify token endpoint during initial load and across subsequent requests, significantly reducing backend overhead and preventing rate limiting.
🔬 Measurement: Verify by adding console logs to `fetchAccessToken` and reloading the dashboard, confirming the token is only fetched once per hour despite multiple components rendering simultaneously.

---
*PR created automatically by Jules for task [11641642825528939957](https://jules.google.com/task/11641642825528939957) started by @Pranav322*