### PR TITLE
⚡ Bolt: Cache Spotify access token fetch promise

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-06-25 - Prevent concurrent Spotify token fetches with Promise caching
+
+**Learning:** In Next.js, concurrent server-side components rendering on a single page load can all hit the same API abstraction (`lib/spotify.ts`) simultaneously. If each call awaits a new `fetch` for an access token without sharing state, it creates an N+1 API bottleneck and risks rate-limiting from the Spotify API.
+**Action:** When creating a server-side abstraction for an external API that multiple components will use, implement an in-memory Promise cache at the module level. Ensure the cache logic properly handles the "pending" state (`tokenExpirationTime === 0`) so concurrent requests await the same in-flight Promise instead of bypassing the cache and making redundant requests. Also, remember to handle `.catch()` to clear the cache so transient errors don't permanently poison it.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,25 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// In-memory cache for the token fetch Promise.
+// This prevents concurrent requests from creating multiple token fetches
+// which can cause redundant API calls and rate-limiting issues.
+let cachedPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it's currently fetching (tokenExpirationTime === 0)
+  // or if the cached token is still valid.
+  if (cachedPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedPromise;
+  }
+
+  // Reset to 0 to indicate a pending request
+  tokenExpirationTime = 0;
+
+  cachedPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +36,25 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Spotify token: ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Set expiration time to slightly before the actual expiration to ensure safety margin
+      // Spotify tokens usually expire in 3600 seconds (1 hour). We subtract 5 mins (300 sec).
+      tokenExpirationTime = now + (data.expires_in - 300) * 1000;
+      return data;
+    })
+    .catch(error => {
+      // Clear cache on error to prevent permanently caching rejected promises
+      cachedPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for the `getAccessToken()` function in `lib/spotify.ts`.\n🎯 Why: Resolves a N+1/thundering herd performance bottleneck where concurrent Next.js server components render simultaneously, triggering multiple simultaneous `fetch` calls to the Spotify API for an access token before the first one completes, risking rate-limiting.\n📊 Impact: Eliminates redundant concurrent API requests to Spotify's token endpoint on initial page load, improving server response times and API quota usage.\n🔬 Measurement: Review network logs to verify only one token request is dispatched when multiple Spotify components (e.g., TopTracks, RecentlyPlayed) mount simultaneously.

---
*PR created automatically by Jules for task [4426608625633353456](https://jules.google.com/task/4426608625633353456) started by @Pranav322*