### PR TITLE
🎨 Palette: [UX improvement] File upload keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - File Upload Keyboard Accessibility
+
+**Learning:** Using Tailwind's `hidden` class on `<input type="file">` removes it from the accessibility tree and keyboard tab order, breaking keyboard navigation for custom file uploads.
+**Action:** Always use `sr-only` instead of `hidden` for file inputs, and apply `focus-within:ring-2 focus-within:outline-none` to their wrapping `<label>` to provide a visual focus indicator for keyboard users.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -160,14 +160,14 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             {/* Custom Upload Section */}
             <div className="mb-8">
               <h3 className="text-white/90 font-medium mb-4">Upload Custom Wallpaper</h3>
-              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5">
+              <label className="flex items-center gap-3 p-4 border border-dashed border-white/20 rounded-lg cursor-pointer hover:bg-white/5 focus-within:ring-2 focus-within:outline-none">
                 <IconUpload className="text-white/60" />
                 <span className="text-white/60">Choose a file or drag it here</span>
                 <input
                   type="file"
                   accept="image/*"
                   onChange={handleFileUpload}
-                  className="hidden"
+                  className="sr-only"
                 />
               </label>
             </div>


### PR DESCRIPTION
### 💡 What:
Improved the accessibility of the "Upload Custom Wallpaper" file input by replacing the `hidden` class with `sr-only`, and adding `focus-within` visual styling to its wrapper label.

### 🎯 Why:
The original implementation used Tailwind's `hidden` class (`display: none`), which completely removed the file input from the accessibility tree. Keyboard users (e.g., using `Tab` navigation) could not focus on or activate the custom upload button. Furthermore, even if they could focus it, there was no visual indicator showing where the focus was.

### 📸 Before/After:
**Before:** The custom upload button was skipped entirely during keyboard navigation.
**After:** The custom upload button is now reachable via `Tab`, and its wrapping label correctly displays a blue focus ring (`focus-within:ring-2`) when focused.

### ♿ Accessibility:
- **Tab Order:** Restored by using `sr-only` so the `<input type="file">` element remains semantically present and focusable while remaining visually hidden.
- **Visual Focus:** Applied `focus-within:ring-2 focus-within:outline-none` to the parent label to provide clear visual feedback to keyboard users.

---
*PR created automatically by Jules for task [6245030228690518763](https://jules.google.com/task/6245030228690518763) started by @Pranav322*