### PR TITLE
⚡ Bolt: Implement Promise cache for Spotify token fetch

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,8 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+## 2024-05-24 - Spotify Token Concurrent Fetch Optimization
+
+**Learning:** When multiple frontend components request data simultaneously, the un-cached `getAccessToken` in `lib/spotify.ts` causes redundant concurrent requests to the Spotify API, leading to potential rate limits and slower page loads. Simply caching the token string isn't enough; caching the pending _Promise_ prevents concurrent calls from slipping through during the fetch.
+**Action:** Implement an in-memory Promise cache (`cachedPromise`) for the access token fetch. Ensure to handle `!response.ok` appropriately, and always attach a `.catch()` block to the cached promise chain to reset `cachedPromise = null` to prevent poisoning the cache with transient errors.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,25 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt Cache Optimization
+// We cache the Promise itself, not just the token, to prevent concurrent
+// requests from initiating multiple fetches before the first one completes.
+let cachedPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // If we have a pending fetch or a valid token, return the cached promise.
+  // We check `tokenExpirationTime === 0` to identify a pending request.
+  if (cachedPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedPromise;
+  }
+
+  // Reset expiration to indicate a pending request
+  tokenExpirationTime = 0;
+
+  cachedPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +36,23 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Spotify token: ${response.status}`);
+      }
+      const data = await response.json();
+      // Tokens usually expire in 3600 seconds. We subtract 60 seconds as a buffer.
+      tokenExpirationTime = Date.now() + (data.expires_in || 3600) * 1000 - 60000;
+      return data;
+    })
+    .catch(error => {
+      // ⚡ Reset the cache on error to prevent poisoning future requests
+      cachedPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 **What**:
Implemented an in-memory Promise cache for `getAccessToken` in `lib/spotify.ts`.

🎯 **Why**:
Multiple frontend components (e.g. `getTopTracks`, `getNowPlaying`) fetch data concurrently when the page loads. Without caching, this caused multiple redundant requests to the Spotify token endpoint at the same time, leading to potential rate limits and slower overall render times. By caching the pending *Promise*, all concurrent calls await the same single fetch request.

📊 **Impact**:
Eliminates duplicate token fetching. Reduces redundant network overhead and Spotify API rate-limit pressure.

🔬 **Measurement**:
The improvement can be verified by observing the network requests to the Spotify API token endpoint when multiple Spotify components load simultaneously; only a single token request will be dispatched.

---
*PR created automatically by Jules for task [17446539257671001598](https://jules.google.com/task/17446539257671001598) started by @Pranav322*