### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent redundant API calls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - [Promise Cache Concurrency Bypass]
+
+**Learning:** When using an in-memory Promise cache with an expiration time, setting the expiration time to `0` to represent a 'pending' state causes a concurrency bypass if the cache hit logic only evaluates `now < expirationTime`. Concurrent requests will bypass the cache because `now < 0` is false, leading to multiple redundant network requests.
+**Action:** Always explicitly check for the pending state (e.g., `expirationTime === 0 || now < expirationTime`) in the cache hit logic to ensure concurrent requests properly await the cached Promise.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,22 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+// Promise cache variables to prevent redundant API calls
+let cachedTokenPromise: Promise<{ access_token: string }> | null = null;
+let tokenExpirationTime = 0;
+
+async function getAccessToken(): Promise<{ access_token: string }> {
+  const now = Date.now();
+
+  // Return the cached promise if it is still valid or currently pending (0)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Set pending state
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +33,24 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token: ${response.status} ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Set expiration slightly less than 1 hour (3600 seconds)
+      tokenExpirationTime = Date.now() + 3500 * 1000;
+      return data;
+    })
+    .catch(error => {
+      // Reset cache on error to prevent poisoning the cache
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implement an in-memory Promise cache for `getAccessToken` in `lib/spotify.ts`.
🎯 Why: Multiple Spotify UI widgets concurrently request data on load, causing redundant concurrent API calls to fetch an access token.
📊 Impact: Eliminates duplicate token fetches, reducing network overhead and preventing potential API rate limits.
🔬 Measurement: Verify by checking network tab or API logs to ensure only one token request is made when multiple widgets render simultaneously.

---
*PR created automatically by Jules for task [14354709590576878854](https://jules.google.com/task/14354709590576878854) started by @Pranav322*