### PR TITLE
⚡ Bolt: Cache Spotify access token to reduce concurrent API calls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-06-09 - [In-Memory Promise Caching for Token Refreshes]
+
+**Learning:** When refreshing an expired cached Promise, evaluating only `now < expirationTime` returns false if `expirationTime` is temporarily 0, causing concurrent requests to incorrectly bypass the cache. Also, failed HTTP responses must be thrown before `.json()` to prevent parsing errors from permanently poisoning the cache.
+**Action:** Explicitly evaluate the pending state (e.g., `tokenExpirationTime === 0 || now < tokenExpirationTime`), throw on `!response.ok`, and append a `.catch()` block to reset the cache variable (e.g., `cachedPromise = null`).

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,24 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt: Added in-memory Promise cache for getAccessToken to prevent redundant
+// concurrent requests to the Spotify API when multiple frontend components request data simultaneously.
+let cachedPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it exists and hasn't expired,
+  // or if a fetch is currently pending (tokenExpirationTime === 0).
+  if (cachedPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedPromise;
+  }
+
+  // Reset expiration time to indicate a pending fetch
+  tokenExpirationTime = 0;
+
+  cachedPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +35,23 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token: ${response.status} ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Set expiration time to 1 hour (3600 seconds) minus a 1-minute buffer
+      tokenExpirationTime = Date.now() + 3600 * 1000 - 60000;
+      return data;
+    })
+    .catch(error => {
+      // Reset the cache variable on error to prevent permanently poisoning the cache
+      cachedPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for `getAccessToken` in `lib/spotify.ts`.

🎯 Why: Multiple frontend components (e.g., top tracks, top artists, recently played) fetch data concurrently, causing redundant parallel requests to the Spotify API for an access token.

📊 Impact: Reduces redundant API calls for token generation, improving backend response time and avoiding rate limits.

🔬 Measurement: Observe network requests in the console or network tab; only one token fetch should occur per expiration cycle, even with multiple simultaneous data requests.

---
*PR created automatically by Jules for task [2340312929999325166](https://jules.google.com/task/2340312929999325166) started by @Pranav322*