### PR TITLE
⚡ Bolt: Cache Spotify access token fetches

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - In-Memory Promise Cache Race Condition
+
+**Learning:** When refreshing an expired cached Promise for the Spotify API, using only `now < expirationTime` for cache hits causes concurrent requests to bypass the cache if `expirationTime` is reset to 0 (pending state), leading to redundant network calls.
+**Action:** Explicitly reset the tracking variable to a pending state (`tokenExpirationTime = 0`) before fetching, and check for this state in the cache hit logic (`tokenExpirationTime === 0 || now < tokenExpirationTime`).

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,18 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt: In-memory Promise cache to prevent redundant concurrent token fetches
+let cachedPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  if (cachedPromise && (tokenExpirationTime === 0 || Date.now() < tokenExpirationTime)) {
+    return cachedPromise;
+  }
+
+  tokenExpirationTime = 0;
+
+  cachedPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +29,21 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Spotify token fetch failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      tokenExpirationTime = Date.now() + 3500 * 1000;
+      return data;
+    })
+    .catch(error => {
+      cachedPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Added an in-memory Promise cache for Spotify access token fetches.
🎯 Why: Multiple concurrent API requests on page load trigger redundant fetches to the Spotify token endpoint, increasing load and latency.
📊 Impact: Reduces Spotify token API calls from multiple concurrent fetches to 1 per hour.
🔬 Measurement: Verify by running the application and observing the network/server logs; only one token fetch should occur per hour.

---
*PR created automatically by Jules for task [11504930544979683268](https://jules.google.com/task/11504930544979683268) started by @Pranav322*