### PR TITLE
⚡ Bolt: [Cache Spotify Access Token to reduce redundant requests]

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-11 - [In-memory Promise Cache for Concurrent API Requests]
+**Learning:** Multiple frontend UI components requesting data simultaneously (like Now Playing, Top Tracks) caused redundant concurrent fetches to the Spotify API for access tokens, exposing an architectural bottleneck where independent components triggered overlapping token requests.
+**Action:** Implemented an in-memory Promise cache that explicitly tracks pending states (`tokenExpirationTime = 0`) and caches the promise chain with a `.catch()` block to handle and reset transient errors, preventing redundant requests.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,24 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// ⚡ Bolt: Implemented an in-memory Promise cache to prevent redundant concurrent requests
+// from multiple UI components (e.g., NowPlaying, TopTracks) loading simultaneously.
+let cachedTokenPromise: Promise<{ access_token: string }> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it exists and hasn't expired,
+  // or if a request is currently pending (expirationTime === 0)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration time to indicate a pending request
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +35,24 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Spotify token fetch failed: ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Tokens typically expire in 3600 seconds. We cache for 3500 seconds to be safe.
+      const expiresIn = data.expires_in || 3600;
+      tokenExpirationTime = now + (expiresIn - 100) * 1000;
+      return data;
+    })
+    .catch(error => {
+      // On error, reset the cache so subsequent requests can try again
+      cachedTokenPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for `getAccessToken` in `lib/spotify.ts`.
🎯 Why: Multiple UI components loading concurrently caused redundant, simultaneous token fetch requests, slowing down the UI and risking rate limits.
📊 Impact: Reduces redundant Spotify API token requests from N (number of components) to 1, significantly improving component load times and reliability.
🔬 Measurement: Verified via a temporary mock test ensuring that `fetch` is only called once for multiple simultaneous token requests.

---
*PR created automatically by Jules for task [9849641456878469232](https://jules.google.com/task/9849641456878469232) started by @Pranav322*