### PR TITLE
⚡ Bolt: Prevent redundant Spotify token fetches via caching

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,4 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2023-10-25 - In-Memory Promise Cache Concurrency Edge Case
+
+**Learning:** When using a tracking variable like `tokenExpirationTime = 0` to denote a pending fetch state, the cache hit logic must explicitly check for this `0` state. Evaluating only `now < tokenExpirationTime` returns false when `tokenExpirationTime` is 0, causing concurrent requests that arrive during the pending state to bypass the cache and trigger redundant fetches.
+**Action:** Always explicitly check for the pending state (e.g., `expirationTime === 0`) in the cache hit condition alongside the time evaluation to correctly serve concurrent requests.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,23 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// Optimization: Cache the token fetch promise to prevent redundant concurrent requests
+// when multiple frontend components load simultaneously.
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0; // 0 denotes a pending state
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return cached promise if we are pending (0) or if the token is still valid
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset to pending state so concurrent calls hit the cache condition above
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +34,24 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Spotify token fetch failed with status: ${response.status}`);
+      }
+      const data = await response.json();
+      // Set expiration slightly before actual expiry (default 3600s) to be safe
+      const expiresIn = data.expires_in || 3600;
+      tokenExpirationTime = now + (expiresIn - 60) * 1000;
+      return data;
+    })
+    .catch(error => {
+      // Clear the cache on error to prevent poisoning
+      cachedTokenPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for `getAccessToken` in `lib/spotify.ts` with expiration logic and concurrency handling.
🎯 Why: Multiple frontend components request Spotify data simultaneously, causing redundant token API calls on page load.
📊 Impact: Reduces duplicate authentication requests to the Spotify API, saving bandwidth and mitigating rate limit risks.
🔬 Measurement: Verified via mock testing that concurrent Spotify API requests only trigger a single token fetch.

---
*PR created automatically by Jules for task [13857303071338981090](https://jules.google.com/task/13857303071338981090) started by @Pranav322*