### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent redundant concurrent API calls

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-06-14 - [In-Memory Promise Cache Concurrency]
+
+**Learning:** When implementing an in-memory Promise cache for an API token, evaluating only `now < expirationTime` fails for concurrent requests because the initial request hasn't resolved to set the expiration time yet (it defaults to 0, so `now < 0` is false). This causes concurrent calls to incorrectly bypass the cache and initiate duplicate requests.
+**Action:** Explicitly reset the tracking variable to a pending state (e.g., `tokenExpirationTime = 0`) before initiating a new fetch, and ensure the cache hit logic explicitly checks for this pending state (`tokenExpirationTime === 0 || now < tokenExpirationTime`).

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,21 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// In-memory cache for the Spotify access token promise to prevent redundant concurrent fetches
+let cachedTokenPromise: Promise<{ access_token: string; expires_in: number }> | null = null;
+let tokenExpirationTime = 0; // 0 indicates pending state
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+  // Return cached promise if we have one and it's either pending (0) or valid (now < expiration)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Set to pending state to batch concurrent requests
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +32,23 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        cachedTokenPromise = null;
+        throw new Error(`Failed to fetch Spotify access token: ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Cache token for a bit less than actual expiration (usually 3600s) to be safe
+      tokenExpirationTime = now + (data.expires_in - 60) * 1000;
+      return data;
+    })
+    .catch(error => {
+      cachedTokenPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache with pending state checks (`tokenExpirationTime === 0`) and failed response validations for `getAccessToken` in `lib/spotify.ts`.

🎯 Why: Multiple frontend components (e.g. NowPlaying, TopTracks, TopArtists) fetch Spotify data simultaneously when the window opens. Previously, this triggered concurrent, overlapping requests to the Spotify token endpoint, creating redundant network overhead and risking rate limits.

📊 Impact: Reduces Spotify token API requests by up to 80% per data refresh. For example, if 5 concurrent UI data fetches fire, the token endpoint is only hit 1 time instead of 5 times.

🔬 Measurement: Verified by mocking `fetch` to confirm multiple concurrent `getAccessToken()` calls resulted in only a single network invocation to the token endpoint.

---
*PR created automatically by Jules for task [11338806681822090002](https://jules.google.com/task/11338806681822090002) started by @Pranav322*