### PR TITLE
🎨 Palette: Add dynamic ARIA labels and focus states to SettingsWindow controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,11 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.
+
+## 2025-02-23 - Dynamic Window Control Labels
+
+**Learning:** Window 'Maximize' buttons need to dynamically reflect their state to provide accurate context to screen readers, and all window controls require focus rings for keyboard accessibility.
+**Action:** When implementing accessibility attributes for window 'Maximize' buttons, ensure the `aria-label` and `title` attributes dynamically reflect the current state (e.g., `isMaximized ? 'Restore' : 'Maximize'`), and apply `focus-visible` classes.

--- a/app/components/windows/SettingsWindow.tsx
+++ b/app/components/windows/SettingsWindow.tsx
@@ -312,21 +312,27 @@ export function SettingsWindow({ onClose, onWallpaperChange }: SettingsWindowPro
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={() => setIsMaximized(!isMaximized)}
-              className="p-2 rounded-full"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconSquare size={14} className="text-white/80" />
             </motion.button>
             <motion.button
               whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
               onClick={onClose}
-              className="p-2 rounded-full"
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none"
             >
               <IconX size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
💡 What: Added aria-label, title, and focus-visible classes to SettingsWindow control buttons. Maximize button dynamically switches to 'Restore' when maximized.
🎯 Why: Icon-only buttons without ARIA labels or focus states are inaccessible to screen readers and keyboard users.
📸 Before/After: Window header controls now show tooltips on hover and have visible focus rings when focused via keyboard.
♿ Accessibility: Ensures window controls provide clear context to screen readers and visual focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [6305400890064612341](https://jules.google.com/task/6305400890064612341) started by @Pranav322*