### PR TITLE
⚡ Bolt: Cache Spotify API tokens to eliminate redundant concurrent requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2024-05-20 - [Spotify API Token Caching]
+
+**Learning:** The Spotify API token fetch was not cached. When multiple frontend components request data simultaneously, it resulted in redundant concurrent requests to the Spotify token API, causing unnecessary network overhead and potentially hitting rate limits.
+**Action:** Implement an in-memory Promise cache for API tokens. Ensure the caching logic explicitly checks for a pending state (e.g., `tokenExpirationTime === 0`) to prevent concurrent requests from bypassing the cache, and explicitly resets the cache variable on failure.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,22 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// In-memory cache for the Spotify access token
+let cachedTokenPromise: Promise<{ access_token: string }> | null = null;
+let tokenExpirationTime: number = 0; // 0 indicates a pending state when a fetch is in progress
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+
+  // Return the cached promise if it exists and hasn't expired, or if a fetch is currently pending (expiration 0)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Reset expiration to 0 to indicate a pending request, preventing concurrent duplicate fetches
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +33,27 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`Spotify token fetch failed with status ${response.status}`);
+      }
+      return response.json();
+    })
+    .then(data => {
+      // Tokens typically expire in 3600 seconds (1 hour). We cache for slightly less (3500 seconds) to be safe.
+      const expiresIn = data.expires_in ? data.expires_in : 3600;
+      tokenExpirationTime = Date.now() + expiresIn * 1000 - 100000;
+      return data;
+    })
+    .catch(error => {
+      // Explicitly reset the cache on failure so we can try again
+      cachedTokenPromise = null;
+      tokenExpirationTime = 0;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for the Spotify `getAccessToken` fetch function in `lib/spotify.ts`.

🎯 Why: Previously, when multiple frontend components (like NowPlaying, TopTracks, TopArtists) simultaneously hit the backend API routes which then invoked `getAccessToken`, it would result in duplicate, concurrent requests being fired to the Spotify authentication endpoint because the access token was not cached globally per instance. This caused unnecessary network overhead, slower collective response times for the frontend UI, and risked hitting Spotify's API rate limits.

📊 Impact: Reduces concurrent network requests to the Spotify Token API from N (where N is the number of frontend components loading simultaneously) to exactly 1 per expiration window. Eliminates duplicate external authentication fetch calls and significantly improves the speed of loading multiple Spotify stats in the UI.

🔬 Measurement: I verified this using a mock testing script (`lib/spotify.test.ts`) that triggered concurrent data endpoints and asserted that the mocked global fetch for the `/token` URL was only called exactly once.

---
*PR created automatically by Jules for task [13594759771334172049](https://jules.google.com/task/13594759771334172049) started by @Pranav322*