### PR TITLE
⚡ Bolt: [performance improvement] Implement Promise Cache for Spotify API tokens

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2026-06-20 - [Promise Cache Concurrency]
+
+**Learning:** When implementing an in-memory Promise cache, setting the expiration tracking variable to 0 (pending state) and checking `(tokenExpirationTime === 0 || now < tokenExpirationTime)` is critical. Checking only `now < tokenExpirationTime` will fail for 0, causing concurrent requests to bypass the cache.
+**Action:** Always explicitly handle the pending state when caching Promises to ensure concurrent requests properly await the initial fetch instead of triggering redundant network calls.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,21 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+// In-memory Promise cache to prevent redundant concurrent fetches to the Spotify API.
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime: number = 0;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const now = Date.now();
+  // Check if we have a cached promise and it hasn't expired (or is currently pending, indicated by 0)
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  // Set to pending state
+  tokenExpirationTime = 0;
+
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +32,24 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Spotify access token: ${response.statusText}`);
+      }
+      const data = await response.json();
+      // Cache for slightly less than the expiration time (which is usually 3600 seconds)
+      // We'll cache it for data.expires_in - 60 seconds to be safe
+      const expiresIn = data.expires_in ? data.expires_in - 60 : 3540;
+      tokenExpirationTime = Date.now() + expiresIn * 1000;
+      return data;
+    })
+    .catch(error => {
+      cachedTokenPromise = null; // Reset cache on network/parsing failure
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 **What:** 
Implemented an in-memory Promise cache for the `getAccessToken()` function in `lib/spotify.ts` with proper expiration and pending-state tracking.

🎯 **Why:**
When the Next.js frontend loads, multiple components (e.g. Now Playing, Top Tracks, Top Artists) concurrently fetch data from Spotify API routes. Since they all internally require an access token, this caused redundant concurrent requests to the Spotify token endpoint. Caching the Promise ensures only one initial token request goes out over the network per hour, and all concurrent components await that same Promise.

📊 **Impact:**
Reduces redundant API requests to `accounts.spotify.com/api/token` during cold initial loads from N (number of active components) down to 1. Decreases load time and saves bandwidth.

🔬 **Measurement:** 
Load the home page with Spotify components active. Monitor network requests to verify `api/token` is hit only once. A dedicated mock test file verified this logic correctly resolves concurrent invocations into a single network call.

---
*PR created automatically by Jules for task [16830974711457208004](https://jules.google.com/task/16830974711457208004) started by @Pranav322*