### PR TITLE
⚡ Bolt: Cache Spotify access token to prevent redundant fetches

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2024-06-23 - Concurrent API Token Fetching Bottleneck
+**Learning:** In a windowed frontend architecture where multiple sub-components (NowPlaying, TopTracks, etc.) mount simultaneously and fetch from distinct backend routes, they can inadvertently trigger parallel N+1 backend requests for the same underlying authentication token if the library wrapper (e.g., `getAccessToken`) lacks in-memory caching.
+**Action:** Implement an in-memory Promise cache that prioritizes checking if the promise exists before checking data expiration. This ensures concurrent requests hook into the same in-flight fetch promise rather than initiating redundant parallel requests.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,19 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
-async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+let cachedTokenPromise: Promise<{ access_token: string; expires_in: number }> | null = null;
+let tokenExpirationTime: number = 0;
+
+async function getAccessToken(): Promise<{ access_token: string; expires_in?: number }> {
+  const now = Date.now();
+  // If we have a promise and it's either pending (expiration is 0) or unexpired, use it.
+  // We reset tokenExpirationTime to 0 right before starting a new fetch to signal "pending".
+  if (cachedTokenPromise && (tokenExpirationTime === 0 || now < tokenExpirationTime)) {
+    return cachedTokenPromise;
+  }
+
+  tokenExpirationTime = 0; // Mark as pending
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +30,21 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch access token: ${response.statusText}`);
+      }
+      const data = await response.json();
+      tokenExpirationTime = Date.now() + (data.expires_in || 3600) * 1000 - 60000; // buffer of 60 seconds
+      return data;
+    })
+    .catch(error => {
+      cachedTokenPromise = null;
+      throw error;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for `getAccessToken` in `lib/spotify.ts`.
🎯 Why: Multiple Spotify window components (NowPlaying, TopTracks, TopArtists, etc.) render simultaneously when the Spotify window opens, triggering ~6 concurrent backend API calls. Each of these backend routes independently called `getAccessToken()`, resulting in 6 parallel network requests to Spotify's token endpoint to fetch the exact same token. This wasted network resources, delayed downstream fetching, and risked rate limiting.
📊 Impact: Reduces parallel Spotify authentication requests from ~6 to 1 per window mount. Subsequent concurrent requests simply attach `.then()` handlers to the already in-flight promise.
🔬 Measurement: Verified with a custom mock test validating that concurrent component data fetches result in exactly 1 call to the token endpoint.

---
*PR created automatically by Jules for task [2330862776767340330](https://jules.google.com/task/2330862776767340330) started by @Pranav322*