### PR TITLE
⚡ Bolt: Cache Spotify token requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,9 @@
 ## 2025-02-12 - [Conditional Rendering vs Code Splitting]
+
 **Learning:** Static imports of components inside conditional blocks (e.g., `{isCLI && <Terminalcomp />}`) are still bundled in the main chunk. Simply wrapping a component in a conditional check does NOT lazy load its code.
 **Action:** Always use `next/dynamic` or `React.lazy` for heavy components that are not visible on initial render, especially for "modes" or "tabs" that are hidden by default.
+
+## 2025-02-12 - [In-Memory API Deduplication]
+
+**Learning:** When multiple frontend components request data from different API routes simultaneously, Next.js server-side code can encounter identical concurrent backend fetches (like token requests). Since API routes in Next.js execute in the same Node.js process (until scaled), module-level variables can serve as a shared cache.
+**Action:** Use an in-memory Promise cache to deduplicate simultaneous external API requests, especially for authentication tokens required by multiple parallel endpoints.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,5 +4,6 @@
 **Action:** When animating interactive elements, always ensure the root interactive element is semantic (`<button>` or `<a>`) and carries the necessary event handlers and ARIA attributes, even if it requires refactoring the animation wrapper.
 
 ## 2025-02-23 - Tooltips for Keyboard Focus
+
 **Learning:** Icon-only buttons often rely on hover tooltips for context, leaving keyboard users guessing. Adding `onFocus`/`onBlur` handlers to show the same tooltip on focus bridges this gap without visual clutter.
 **Action:** When creating tooltips for icon-only elements, trigger visibility on `hover || focus` and ensure the interactive element itself (not just the inner icon) handles the focus events.

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -8,8 +8,19 @@ const TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/me/top/tracks';
 const TOP_ARTISTS_ENDPOINT = 'https://api.spotify.com/v1/me/top/artists';
 const RECENTLY_PLAYED_ENDPOINT = 'https://api.spotify.com/v1/me/player/recently-played';
 
+let cachedTokenPromise: Promise<any> | null = null;
+let tokenExpirationTime = 0;
+let isFetching = false;
+
 async function getAccessToken() {
-  const response = await fetch(TOKEN_ENDPOINT, {
+  if (cachedTokenPromise) {
+    if (isFetching || Date.now() < tokenExpirationTime) {
+      return cachedTokenPromise;
+    }
+  }
+
+  isFetching = true;
+  cachedTokenPromise = fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${basic}`,
@@ -19,9 +30,24 @@ async function getAccessToken() {
       grant_type: 'refresh_token',
       refresh_token: refresh_token!,
     }),
-  });
+  })
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch token: ${response.status}`);
+      }
+      const data = await response.json();
+      tokenExpirationTime = Date.now() + (data.expires_in - 60) * 1000;
+      return data;
+    })
+    .catch(error => {
+      cachedTokenPromise = null;
+      throw error;
+    })
+    .finally(() => {
+      isFetching = false;
+    });
 
-  return response.json();
+  return cachedTokenPromise;
 }
 
 export async function getNowPlaying() {


### PR DESCRIPTION
💡 What: Implemented an in-memory Promise cache for `getAccessToken` in `lib/spotify.ts` and added a learning to the Bolt journal.
🎯 Why: Multiple frontend components (Now Playing, Top Tracks, Top Artists) fetch data in parallel, triggering redundant concurrent authentication token requests to the Spotify API, wasting network resources and adding latency.
📊 Impact: Eliminates duplicate token requests, saving at least 1 round trip per parallel endpoint load during the token's lifetime.
🔬 Measurement: Verified locally that concurrent calls to `getAccessToken` only trigger a single `fetch` to `accounts.spotify.com/api/token`. Network traces or server logs will show `getAccessToken` executing only once until the cache expires.

---
*PR created automatically by Jules for task [16007360222340185610](https://jules.google.com/task/16007360222340185610) started by @Pranav322*