### PR TITLE
🎨 Palette: Add accessibility attributes to SpotifyWindow controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,8 @@
 
 **Learning:** Using Tailwind's `hidden` class on `<input type="file">` removes it from the accessibility tree and keyboard tab order, breaking keyboard navigation for custom file uploads.
 **Action:** Always use `sr-only` instead of `hidden` for file inputs, and apply `focus-within:ring-2 focus-within:outline-none` to their wrapping `<label>` to provide a visual focus indicator for keyboard users.
+
+## 2025-02-23 - Consistency in Window Controls Accessibility
+
+**Learning:** When creating custom window implementations, accessibility attributes (like `aria-label`, `title`, and `focus-visible` styles) are easily overlooked if they aren't standardized. The missing attributes in the `SpotifyWindow` highlight the importance of enforcing shared, accessible UI components.
+**Action:** Ensure all new window implementations either use a shared accessible component for header controls (like `WindowControls`) or explicitly replicate the full suite of ARIA attributes and focus styles found in established components like `AboutWindow`.

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -41,17 +41,26 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
           <div className="flex items-center gap-4">
             <button
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50 rounded-full p-1"
             >
               <IconMinus size={18} />
             </button>
             <button
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50 rounded-full p-1"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50 rounded-full p-1"
+            >
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-label`, `title`, and `focus-visible` styling to the minimize, maximize, and close buttons in the SpotifyWindow header.
🎯 Why: The window control buttons were missing aria-labels and title attributes, making them inaccessible to screen readers. They also lacked visual focus indicators for keyboard navigation.
📸 Before/After: N/A (Visual change is limited to keyboard focus state)
♿ Accessibility: Screen readers can now properly identify the purpose of the window controls (including dynamic 'Maximize' / 'Restore' states). Keyboard users now have a visible focus ring when navigating to these buttons.

---
*PR created automatically by Jules for task [450439353938919921](https://jules.google.com/task/450439353938919921) started by @Pranav322*