### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate and cache client-side Spotify API fetches

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When multiple Next.js server components request data concurrently (e.g., Spotify API), they all trigger parallel calls to the token endpoint. Caching just the resolved token isn't enough; we must cache the _Promise_ of the fetch to prevent redundant concurrent requests. Also, tracking a "pending" state (`expiration === 0`) is required to avoid cache misses during the initial fetch.
 **Action:** Use an in-memory Promise cache with explicit error `.catch()` clearing for high-concurrency external API authentication endpoints to avoid rate limits (429s).
+
+## 2025-02-12 - [Client-Side Promise Caching for Concurrent Sibling Requests]
+
+**Learning:** When sibling components (like TopArtists and TopGenres) mount simultaneously and fetch the same endpoint, they trigger parallel network requests to the Next.js API, causing redundant backend processing and potential rate limits.
+**Action:** Use an in-memory client-side Promise cache Map to deduplicate concurrent identical `fetch` requests across the application, returning the pending promise for subsequent callers.

--- a/app/components/spotify/Playlists.tsx
+++ b/app/components/spotify/Playlists.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { IconPlaylist } from '@tabler/icons-react';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { fetchWithCache } from './api';
 interface Playlist {
   name: string;
   image: string;
@@ -15,8 +16,7 @@ export function Playlists() {
   useEffect(() => {
     const fetchPlaylists = async () => {
       try {
-        const res = await fetch('/api/spotify/playlists');
-        const data = await res.json();
+        const data = await fetchWithCache('/api/spotify/playlists');
         setPlaylists(data.playlists);
       } finally {
         setLoading(false);

--- a/app/components/spotify/RecentlyPlayed.tsx
+++ b/app/components/spotify/RecentlyPlayed.tsx
@@ -2,6 +2,7 @@ import { IconClock } from '@tabler/icons-react';
 import { useState, useEffect } from 'react';
 import { Track } from '@/types/spotify';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { fetchWithCache } from './api';
 
 export function RecentlyPlayed() {
   const [tracks, setTracks] = useState<Track[]>([]);
@@ -10,8 +11,7 @@ export function RecentlyPlayed() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/spotify/recently-played');
-        const { tracks } = await res.json();
+        const { tracks } = await fetchWithCache('/api/spotify/recently-played');
         setTracks(tracks);
       } catch (error) {
         console.error('Error fetching recently played:', error);

--- a/app/components/spotify/TopArtists.tsx
+++ b/app/components/spotify/TopArtists.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { fetchWithCache } from './api';
 
 interface Artist {
   name: string;
@@ -15,8 +16,7 @@ export function TopArtists() {
   useEffect(() => {
     const fetchTopArtists = async () => {
       try {
-        const res = await fetch('/api/spotify/top-artists');
-        const data = await res.json();
+        const data = await fetchWithCache('/api/spotify/top-artists');
         setArtists(data.artists);
       } finally {
         setLoading(false);

--- a/app/components/spotify/TopGenres.tsx
+++ b/app/components/spotify/TopGenres.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { fetchWithCache } from './api';
 
 export function TopGenres() {
   const [genres, setGenres] = useState<{ genre: string; count: number }[]>([]);
 
   useEffect(() => {
     const fetchGenres = async () => {
-      const res = await fetch('/api/spotify/top-artists');
-      const data = await res.json();
+      const data = await fetchWithCache('/api/spotify/top-artists');
       const genreCount = data.artists.reduce((acc: any, artist: any) => {
         artist.genres.forEach((genre: string) => {
           acc[genre] = (acc[genre] || 0) + 1;

--- a/app/components/spotify/TopTracks.tsx
+++ b/app/components/spotify/TopTracks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IconMusic } from '@tabler/icons-react';
+import { fetchWithCache } from './api';
 
 interface Track {
   title: string;
@@ -15,8 +16,7 @@ export function TopTracks() {
   useEffect(() => {
     const fetchTopTracks = async () => {
       try {
-        const res = await fetch('/api/spotify/top-tracks');
-        const data = await res.json();
+        const data = await fetchWithCache('/api/spotify/top-tracks');
         setTracks(data.tracks);
       } catch (error) {
         console.error('Error fetching top tracks:', error);

--- a/app/components/spotify/api.ts
+++ b/app/components/spotify/api.ts
@@ -1,0 +1,23 @@
+const cache = new Map<string, { promise: Promise<any>; expiresAt: number }>();
+
+export function fetchWithCache(url: string, ttl = 300000) {
+  const now = Date.now();
+  const cached = cache.get(url);
+
+  if (cached && cached.expiresAt > now) {
+    return cached.promise;
+  }
+
+  const promise = fetch(url)
+    .then(res => {
+      if (!res.ok) throw new Error(`Fetch failed: ${res.statusText}`);
+      return res.json();
+    })
+    .catch(error => {
+      cache.delete(url);
+      throw error;
+    });
+
+  cache.set(url, { promise, expiresAt: now + ttl });
+  return promise;
+}


### PR DESCRIPTION
💡 What:
Implemented an in-memory client-side Promise cache using a `Map` within a new `api.ts` file, and refactored multiple Spotify components (TopArtists, TopGenres, TopTracks, Playlists, RecentlyPlayed) to use `fetchWithCache()` instead of a raw `fetch()`.

🎯 Why:
Sibling components (like `TopArtists` and `TopGenres`) mount simultaneously and previously fired concurrent, identical fetch requests to Next.js API endpoints (e.g. `/api/spotify/top-artists`). This deduplication prevents duplicate processing on the backend, saves client bandwidth, and allows for instant loading when windows are closed and re-opened.

📊 Impact:
Reduces redundant API network requests on the frontend by 50% for sibling endpoints (e.g. `TopGenres` and `TopArtists`), and prevents unnecessary re-fetching if a user frequently toggles the Spotify window, as data is cached for 5 minutes.

🔬 Measurement:
Open the application and view the Network tab in the Developer Tools. When mounting the Spotify Window, you will now observe only a single request to `/api/spotify/top-artists`, whereas previously there would be two overlapping requests. Toggling the window open/closed within 5 minutes will instantly load from cache rather than dispatching new network requests.

---
*PR created automatically by Jules for task [11406254344171627788](https://jules.google.com/task/11406254344171627788) started by @Pranav322*