### PR TITLE
⚡ Bolt: [Client-side Promise Cache Deduplication]

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When multiple Next.js server components request data concurrently (e.g., Spotify API), they all trigger parallel calls to the token endpoint. Caching just the resolved token isn't enough; we must cache the _Promise_ of the fetch to prevent redundant concurrent requests. Also, tracking a "pending" state (`expiration === 0`) is required to avoid cache misses during the initial fetch.
 **Action:** Use an in-memory Promise cache with explicit error `.catch()` clearing for high-concurrency external API authentication endpoints to avoid rate limits (429s).
+
+## 2025-02-13 - [Client-Side Promise Caching for Deduplication]
+
+**Learning:** Client-side sibling components (like TopArtists and TopGenres) fetching the exact same API endpoint simultaneously will trigger redundant network requests, impacting performance and unnecessarily loading the backend. Simple responses cache states aren't sufficient for concurrent mounting components.
+**Action:** Implement an in-memory client-side Promise cache (e.g., using a Map) to deduplicate concurrent fetch requests, returning the pending Promise to all simultaneous callers instead of firing duplicate fetches.

--- a/app/components/spotify/TopArtists.tsx
+++ b/app/components/spotify/TopArtists.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { deduplicatedFetchJSON } from '@/lib/fetch';
 
 interface Artist {
   name: string;
@@ -15,8 +16,7 @@ export function TopArtists() {
   useEffect(() => {
     const fetchTopArtists = async () => {
       try {
-        const res = await fetch('/api/spotify/top-artists');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/top-artists');
         setArtists(data.artists);
       } finally {
         setLoading(false);

--- a/app/components/spotify/TopGenres.tsx
+++ b/app/components/spotify/TopGenres.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { deduplicatedFetchJSON } from '@/lib/fetch';
 
 export function TopGenres() {
   const [genres, setGenres] = useState<{ genre: string; count: number }[]>([]);
 
   useEffect(() => {
     const fetchGenres = async () => {
-      const res = await fetch('/api/spotify/top-artists');
-      const data = await res.json();
+      const data = await deduplicatedFetchJSON('/api/spotify/top-artists');
       const genreCount = data.artists.reduce((acc: any, artist: any) => {
         artist.genres.forEach((genre: string) => {
           acc[genre] = (acc[genre] || 0) + 1;

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,0 +1,34 @@
+const cache = new Map<string, Promise<any>>();
+
+/**
+ * Deduplicates concurrent GET requests to the same URL by caching the Promise.
+ * Prevents sibling components from triggering duplicate network requests.
+ */
+export function deduplicatedFetchJSON<T = any>(url: string): Promise<T> {
+  if (cache.has(url)) {
+    return cache.get(url)!;
+  }
+
+  const promise = fetch(url)
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      return response.json();
+    })
+    .catch(error => {
+      cache.delete(url);
+      throw error;
+    })
+    .finally(() => {
+      // Clear from cache after a short delay so future requests (e.g. polling) work
+      setTimeout(() => {
+        if (cache.get(url) === promise) {
+          cache.delete(url);
+        }
+      }, 500);
+    });
+
+  cache.set(url, promise);
+  return promise;
+}


### PR DESCRIPTION
💡 What: Introduced a `deduplicatedFetchJSON` utility in `lib/fetch.ts` that explicitly caches the pending fetch Promise for external API calls. Refactored `TopArtists.tsx` and `TopGenres.tsx` to use this new utility instead of raw `fetch`.

🎯 Why: Two client-side sibling components (`TopArtists` and `TopGenres`) were concurrently calling `/api/spotify/top-artists` during initialization. Since the backend responds to the requests concurrently, the standard browser fetch behavior does not automatically deduplicate the identical GET request, leading to redundant network traffic and an unnecessary duplicate API load on the backend server.

📊 Impact: Halves the network requests made to `/api/spotify/top-artists` when both components mount. Resolves a redundant 2x load multiplier on the backend for that specific external integration.

🔬 Measurement: `git diff` confirms the files correctly import and use `deduplicatedFetchJSON`. The added temporary tests successfully mocked global fetch, executed concurrent requests, and asserted that `global.fetch` was only invoked exactly once. All core project linters and backend tests passed smoothly.

---
*PR created automatically by Jules for task [13249261068760157696](https://jules.google.com/task/13249261068760157696) started by @Pranav322*