### PR TITLE
🎨 Palette: Add missing accessibility attributes to window controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,8 @@
 
 **Learning:** Using Tailwind's `hidden` class on `<input type="file">` removes it from the accessibility tree and keyboard tab order, breaking keyboard navigation for custom file uploads.
 **Action:** Always use `sr-only` instead of `hidden` for file inputs, and apply `focus-within:ring-2 focus-within:outline-none` to their wrapping `<label>` to provide a visual focus indicator for keyboard users.
+
+## 2025-02-23 - Reused Layout Accessibility
+
+**Learning:** When UI patterns (like window control headers) are repeated across multiple files rather than abstracted into a single shared component, accessibility attributes (ARIA labels, titles, focus visible styles) often get missed in some files, leading to inconsistent screen reader and keyboard experiences.
+**Action:** Always audit all instances of a repeated layout pattern across the codebase to ensure consistent implementation of accessibility attributes and focus indicators.

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -48,8 +48,10 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
               onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -38,22 +38,34 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
             <IconBrandSpotify size={20} className="text-[#1DB954]" />
             <span className="text-white/90 text-sm font-medium">Spotify Stats</span>
           </div>
-          <div className="flex items-center gap-4">
-            <button
+          <div className="flex items-center gap-1">
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
+              aria-label="Minimize"
+              title="Minimize"
             >
-              <IconMinus size={18} />
-            </button>
-            <button
+              <IconMinus size={14} className="text-white/80" />
+            </motion.button>
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
             >
-              <IconSquare size={16} />
-            </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
-              <IconX size={20} />
-            </button>
+              <IconSquare size={14} className="text-white/80" />
+            </motion.button>
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
+              onClick={onClose}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
+              aria-label="Close"
+              title="Close"
+            >
+              <IconX size={14} className="text-white/80" />
+            </motion.button>
           </div>
         </motion.div>
 


### PR DESCRIPTION
💡 What: Added missing `aria-label`, `title`, and `focus-visible` styles to the minimize button in `GamesWindow.tsx` and all header control buttons (minimize, maximize, close) in `SpotifyWindow.tsx`. Also converted the `SpotifyWindow` buttons to use `motion.button` for consistent hover animations with the rest of the application.
🎯 Why: Window header controls are visually represented only by icons. Without ARIA labels and titles, screen reader users cannot determine their purpose. The absence of `focus-visible` styles also made these controls invisible to keyboard navigators. This change brings these two outlier windows into alignment with the established accessibility baseline used across the rest of the window components.
📸 Before/After: N/A - primarily non-visual semantic and focus state changes. Hover animations on Spotify window controls now match other windows.
♿ Accessibility: Improved keyboard navigation via clear focus rings and ensured screen readers correctly announce control button actions (e.g., "Minimize", "Maximize", "Restore").

---
*PR created automatically by Jules for task [18039660897118379896](https://jules.google.com/task/18039660897118379896) started by @Pranav322*