### PR TITLE
⚡ Bolt: [performance improvement] Deduplicate concurrent client-side API requests

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When multiple Next.js server components request data concurrently (e.g., Spotify API), they all trigger parallel calls to the token endpoint. Caching just the resolved token isn't enough; we must cache the _Promise_ of the fetch to prevent redundant concurrent requests. Also, tracking a "pending" state (`expiration === 0`) is required to avoid cache misses during the initial fetch.
 **Action:** Use an in-memory Promise cache with explicit error `.catch()` clearing for high-concurrency external API authentication endpoints to avoid rate limits (429s).
+
+## 2025-10-24 - [Client-Side Promise Caching for Deduplicating Fetch Requests]
+
+**Learning:** Client-side sibling components (like TopArtists and TopGenres) fetching the same endpoint simultaneously trigger duplicate network requests, leading to redundant backend processing and potential rate-limiting.
+**Action:** Implement an in-memory client-side Promise cache (e.g., using a Map) to deduplicate concurrent fetch requests across frontend components.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 node_modules
 .next
 build
-dist 
+dist pranav/.venv/**
+pranav/.pytest_cache/**

--- a/app/components/spotify/NowPlaying.tsx
+++ b/app/components/spotify/NowPlaying.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IconMusic, IconPlayerPlay, IconPlayerPause } from '@tabler/icons-react';
+import { deduplicatedFetchJSON } from '@/lib/fetch';
 
 interface NowPlayingResponse {
   isPlaying: boolean;
@@ -17,8 +18,7 @@ export function NowPlaying() {
   useEffect(() => {
     const fetchNowPlaying = async () => {
       try {
-        const res = await fetch('/api/spotify/now-playing');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/now-playing');
         setData(data);
       } catch (error) {
         console.error('Error fetching now playing:', error);

--- a/app/components/spotify/Playlists.tsx
+++ b/app/components/spotify/Playlists.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { IconPlaylist } from '@tabler/icons-react';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { deduplicatedFetchJSON } from '@/lib/fetch';
 interface Playlist {
   name: string;
   image: string;
@@ -15,8 +16,7 @@ export function Playlists() {
   useEffect(() => {
     const fetchPlaylists = async () => {
       try {
-        const res = await fetch('/api/spotify/playlists');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/playlists');
         setPlaylists(data.playlists);
       } finally {
         setLoading(false);

--- a/app/components/spotify/RecentlyPlayed.tsx
+++ b/app/components/spotify/RecentlyPlayed.tsx
@@ -2,6 +2,7 @@ import { IconClock } from '@tabler/icons-react';
 import { useState, useEffect } from 'react';
 import { Track } from '@/types/spotify';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { deduplicatedFetchJSON } from '@/lib/fetch';
 
 export function RecentlyPlayed() {
   const [tracks, setTracks] = useState<Track[]>([]);
@@ -10,8 +11,7 @@ export function RecentlyPlayed() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/spotify/recently-played');
-        const { tracks } = await res.json();
+        const { tracks } = await deduplicatedFetchJSON('/api/spotify/recently-played');
         setTracks(tracks);
       } catch (error) {
         console.error('Error fetching recently played:', error);

--- a/app/components/spotify/TopArtists.tsx
+++ b/app/components/spotify/TopArtists.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { deduplicatedFetchJSON } from '@/lib/fetch';
 
 interface Artist {
   name: string;
@@ -15,8 +16,7 @@ export function TopArtists() {
   useEffect(() => {
     const fetchTopArtists = async () => {
       try {
-        const res = await fetch('/api/spotify/top-artists');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/top-artists');
         setArtists(data.artists);
       } finally {
         setLoading(false);

--- a/app/components/spotify/TopGenres.tsx
+++ b/app/components/spotify/TopGenres.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { deduplicatedFetchJSON } from '@/lib/fetch';
 
 export function TopGenres() {
   const [genres, setGenres] = useState<{ genre: string; count: number }[]>([]);
 
   useEffect(() => {
     const fetchGenres = async () => {
-      const res = await fetch('/api/spotify/top-artists');
-      const data = await res.json();
+      const data = await deduplicatedFetchJSON('/api/spotify/top-artists');
       const genreCount = data.artists.reduce((acc: any, artist: any) => {
         artist.genres.forEach((genre: string) => {
           acc[genre] = (acc[genre] || 0) + 1;

--- a/app/components/spotify/TopTracks.tsx
+++ b/app/components/spotify/TopTracks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IconMusic } from '@tabler/icons-react';
+import { deduplicatedFetchJSON } from '@/lib/fetch';
 
 interface Track {
   title: string;
@@ -15,8 +16,7 @@ export function TopTracks() {
   useEffect(() => {
     const fetchTopTracks = async () => {
       try {
-        const res = await fetch('/api/spotify/top-tracks');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/top-tracks');
         setTracks(data.tracks);
       } catch (error) {
         console.error('Error fetching top tracks:', error);

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,0 +1,35 @@
+/**
+ * In-memory cache to deduplicate concurrent fetch requests.
+ * By caching the Promise, if multiple components request the same URL
+ * simultaneously (e.g., TopArtists and TopGenres fetching /api/spotify/top-artists),
+ * they will all wait for the single network request to complete.
+ */
+const pendingFetches = new Map<string, Promise<any>>();
+
+export function deduplicatedFetchJSON<T = any>(url: string, options?: RequestInit): Promise<T> {
+  // We stringify the options to ensure requests with different options (like POST vs GET)
+  // don't incorrectly share the same cached Promise.
+  const cacheKey = `${url}-${JSON.stringify(options || {})}`;
+
+  if (pendingFetches.has(cacheKey)) {
+    return pendingFetches.get(cacheKey) as Promise<T>;
+  }
+
+  const promise = fetch(url, options)
+    .then(res => {
+      if (!res.ok) {
+        throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+      }
+      return res.json();
+    })
+    .catch(error => {
+      pendingFetches.delete(cacheKey);
+      throw error;
+    })
+    .finally(() => {
+      pendingFetches.delete(cacheKey);
+    });
+
+  pendingFetches.set(cacheKey, promise);
+  return promise;
+}


### PR DESCRIPTION
💡 What: Implemented a client-side in-memory Promise cache (`deduplicatedFetchJSON`) to deduplicate concurrent fetch requests across React components.

🎯 Why: Sibling components (`TopArtists` and `TopGenres`) were concurrently fetching `/api/spotify/top-artists` when the Spotify window opened, causing duplicate network requests and redundant backend processing.

📊 Impact: Reduces network requests to the `/api/spotify/top-artists` endpoint by 50% on window load (and ensures no duplication occurs on any endpoints utilizing this wrapper).

🔬 Measurement: Verify the network tab in DevTools when opening the Spotify window. Observe a single request to `top-artists` rather than two simultaneous ones.

---
*PR created automatically by Jules for task [9811467322070160814](https://jules.google.com/task/9811467322070160814) started by @Pranav322*