### PR TITLE
🎨 Palette: Add accessible labels to window controls in Spotify and Games

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,8 @@
 
 **Learning:** Using Tailwind's `hidden` class on `<input type="file">` removes it from the accessibility tree and keyboard tab order, breaking keyboard navigation for custom file uploads.
 **Action:** Always use `sr-only` instead of `hidden` for file inputs, and apply `focus-within:ring-2 focus-within:outline-none` to their wrapping `<label>` to provide a visual focus indicator for keyboard users.
+
+## 2025-02-23 - Interactive Controls in Games and Spotify Windows
+
+**Learning:** Sibling components implementing similar windowing functionality (`GamesWindow.tsx`, `SpotifyWindow.tsx`) frequently miss basic ARIA attributes (`aria-label`, `title`) and keyboard focus indicators (`focus-visible`) for their icon-only window controls (Minimize, Maximize, Close) because they do not share a common UI abstract element.
+**Action:** Always audit icon-only controls across all window components to ensure consistent accessibility markers and visual focus hints are applied. For toggle states like Maximize, use dynamic `aria-label`s based on state (e.g. `aria-label={isMaximized ? 'Restore' : 'Maximize'}`).

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -48,7 +48,9 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
               onClick={handleMinimize}
             >
               <IconMinus size={14} className="text-white/80" />

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -41,17 +41,26 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
           <div className="flex items-center gap-4">
             <button
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50 rounded-sm"
             >
               <IconMinus size={18} />
             </button>
             <button
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50 rounded-sm"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className="text-white/50 hover:text-white transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50 rounded-sm"
+            >
               <IconX size={20} />
             </button>
           </div>


### PR DESCRIPTION
💡 What: Added `aria-label`, `title`, and `focus-visible` styles to the window control buttons (Minimize, Maximize, Close) in `GamesWindow.tsx` and `SpotifyWindow.tsx`.
🎯 Why: Screen readers could not announce these icon-only buttons, and keyboard users lacked focus indicators, making the interface difficult to navigate for non-mouse users.
📸 Before/After: N/A (Visuals remain the same, changes are structural and behavior-based on focus/hover).
♿ Accessibility: Greatly improved screen reader and keyboard accessibility for window components by making the controls discernible and focusable.

---
*PR created automatically by Jules for task [7423603769939573024](https://jules.google.com/task/7423603769939573024) started by @Pranav322*