### PR TITLE
🎨 Palette: Fix window controls accessibility and handlers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,8 @@
 
 **Learning:** Using Tailwind's `hidden` class on `<input type="file">` removes it from the accessibility tree and keyboard tab order, breaking keyboard navigation for custom file uploads.
 **Action:** Always use `sr-only` instead of `hidden` for file inputs, and apply `focus-within:ring-2 focus-within:outline-none` to their wrapping `<label>` to provide a visual focus indicator for keyboard users.
+
+## 2025-02-23 - Accessibility Batch Updates
+
+**Learning:** When making accessibility updates (like adding ARIA attributes to a specific button), it is critical to ensure that any associated interaction handlers (e.g., `onClick`) are not only added to the element, but also correctly defined and scoped within the component. The `request_code_review` tool highlighted a regression where `onClick={handleMinimize}` was added, but assumed to exist, potentially breaking the build.
+**Action:** When adding missing interaction handlers alongside accessibility attributes, always manually verify (e.g., using `grep`) that the handler function is actually declared within the component's scope before committing the change.

--- a/app/components/windows/AboutWindow.tsx
+++ b/app/components/windows/AboutWindow.tsx
@@ -49,6 +49,7 @@ export default function AboutWindow({ onClose }: AboutWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              onClick={handleMinimize}
               aria-label="Minimize"
               title="Minimize"
               className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"

--- a/app/components/windows/BooksWindow.tsx
+++ b/app/components/windows/BooksWindow.tsx
@@ -132,6 +132,7 @@ export function BooksWindow({ onClose }: BooksWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              onClick={handleMinimize}
               aria-label="Minimize"
               title="Minimize"
               className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -48,8 +48,10 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
               onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/PdfWindow.tsx
+++ b/app/components/windows/PdfWindow.tsx
@@ -39,6 +39,7 @@ export function PdfWindow({ onClose, filePath }: PdfWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              onClick={handleMinimize}
               aria-label="Minimize"
               title="Minimize"
               className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"

--- a/app/components/windows/PranavChatWindow.tsx
+++ b/app/components/windows/PranavChatWindow.tsx
@@ -127,6 +127,7 @@ export function PranavChatWindow({ onClose }: PranavChatWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              onClick={handleMinimize}
               aria-label="Minimize"
               title="Minimize"
               className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"

--- a/app/components/windows/ProjectsWindow.tsx
+++ b/app/components/windows/ProjectsWindow.tsx
@@ -44,6 +44,7 @@ export function ProjectsWindow({ onClose }: ProjectsWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              onClick={handleMinimize}
               aria-label="Minimize"
               title="Minimize"
               className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"

--- a/app/components/windows/SkillsWindow.tsx
+++ b/app/components/windows/SkillsWindow.tsx
@@ -53,6 +53,7 @@ export function SkillsWindow({ onClose }: SkillsWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
+              onClick={handleMinimize}
               aria-label="Minimize"
               title="Minimize"
               className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -41,17 +41,26 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
           <div className="flex items-center gap-4">
             <button
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
+              className="text-white/50 hover:text-white transition-colors rounded focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={18} />
             </button>
             <button
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="text-white/50 hover:text-white transition-colors rounded focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className="text-white/50 hover:text-white transition-colors rounded focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
+            >
               <IconX size={20} />
             </button>
           </div>

--- a/app/privacy/shotted/page.tsx
+++ b/app/privacy/shotted/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -131,9 +132,9 @@ export default function ShottedPrivacyPolicy() {
         <div className="mt-16 border-t border-white/10 pt-8 text-xs text-[#9aa0a6]">
           <p>
             Shotted — made by{' '}
-            <a href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
+            <Link href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
               Pranav
-            </a>
+            </Link>
           </p>
         </div>
       </div>


### PR DESCRIPTION
💡 What: Added full accessibility attributes (`aria-label`, `title`, and `focus-visible` styles) to window control buttons across `GamesWindow` and `SpotifyWindow`. Fixed missing `onClick` handlers for Minimize buttons in various other windows. Fixed a Next.js lint warning by switching to `<Link>` in the privacy policy.
🎯 Why: To make window controls fully accessible for screen reader and keyboard users.
📸 Before/After: Visual focus rings will now correctly outline the interactive window controls, and tooltips will appear to identify icon-only buttons.
♿ Accessibility: Increased context for screen readers and fixed keyboard tab navigation styling on repeated control patterns.

---
*PR created automatically by Jules for task [3805452109466787561](https://jules.google.com/task/3805452109466787561) started by @Pranav322*