### PR TITLE
⚡ Bolt: Deduplicate /api/spotify/top-artists requests

### DIFF
--- a/app/components/spotify/TopArtists.tsx
+++ b/app/components/spotify/TopArtists.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { deduplicatedFetchJSON } from '../../../lib/fetch';
 
 interface Artist {
   name: string;
@@ -15,8 +16,7 @@ export function TopArtists() {
   useEffect(() => {
     const fetchTopArtists = async () => {
       try {
-        const res = await fetch('/api/spotify/top-artists');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/top-artists');
         setArtists(data.artists);
       } finally {
         setLoading(false);

--- a/app/components/spotify/TopGenres.tsx
+++ b/app/components/spotify/TopGenres.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { deduplicatedFetchJSON } from '../../../lib/fetch';
 
 export function TopGenres() {
   const [genres, setGenres] = useState<{ genre: string; count: number }[]>([]);
 
   useEffect(() => {
     const fetchGenres = async () => {
-      const res = await fetch('/api/spotify/top-artists');
-      const data = await res.json();
+      const data = await deduplicatedFetchJSON('/api/spotify/top-artists');
       const genreCount = data.artists.reduce((acc: any, artist: any) => {
         artist.genres.forEach((genre: string) => {
           acc[genre] = (acc[genre] || 0) + 1;

--- a/app/privacy/shotted/page.tsx
+++ b/app/privacy/shotted/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy — Shotted',
@@ -131,9 +132,9 @@ export default function ShottedPrivacyPolicy() {
         <div className="mt-16 border-t border-white/10 pt-8 text-xs text-[#9aa0a6]">
           <p>
             Shotted — made by{' '}
-            <a href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
+            <Link href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
               Pranav
-            </a>
+            </Link>
           </p>
         </div>
       </div>

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,0 +1,49 @@
+const fetchPromiseCache = new Map<string, Promise<any>>();
+
+/**
+ * Deduplicates concurrent GET requests to the same URL.
+ * Uses an in-memory Map to store the Promise of the fetch request.
+ * Useful for sibling client components fetching the same API simultaneously.
+ */
+export async function deduplicatedFetchJSON<T = any>(
+  url: string,
+  options?: RequestInit
+): Promise<T> {
+  // We only deduplicate GET requests
+  const method = options?.method?.toUpperCase() || 'GET';
+  if (method !== 'GET') {
+    const res = await fetch(url, options);
+    if (!res.ok) throw new Error(`Fetch failed: ${res.statusText}`);
+    return res.json();
+  }
+
+  const cacheKey = url;
+
+  if (fetchPromiseCache.has(cacheKey)) {
+    return fetchPromiseCache.get(cacheKey);
+  }
+
+  const promise = fetch(url, options)
+    .then(async response => {
+      if (!response.ok) {
+        throw new Error(`Fetch failed: ${response.statusText}`);
+      }
+      return response.json();
+    })
+    .catch(error => {
+      fetchPromiseCache.delete(cacheKey);
+      throw error;
+    })
+    .finally(() => {
+      // Clear the cache after the promise resolves/rejects
+      // This ensures we only deduplicate *concurrent* requests, not cache responses forever.
+      setTimeout(() => {
+        if (fetchPromiseCache.get(cacheKey) === promise) {
+          fetchPromiseCache.delete(cacheKey);
+        }
+      }, 0);
+    });
+
+  fetchPromiseCache.set(cacheKey, promise);
+  return promise;
+}


### PR DESCRIPTION
💡 What: Implement an in-memory client-side Promise cache in `lib/fetch.ts` using `deduplicatedFetchJSON` to deduplicate concurrent requests to `/api/spotify/top-artists` from sibling components.
🎯 Why: Both `TopGenres` and `TopArtists` fetch the same data simultaneously on mount, causing duplicate network requests and redundant backend processing.
📊 Impact: Eliminates duplicate API requests on initial render, reducing backend load and saving network bandwidth.
🔬 Measurement: Verify using the browser network tab that `/api/spotify/top-artists` is only requested once on `SpotifyWindow` open.

---
*PR created automatically by Jules for task [7096379097750594774](https://jules.google.com/task/7096379097750594774) started by @Pranav322*