### PR TITLE
🎨 Palette: Add accessible window controls for Games and Spotify windows

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,8 @@
 
 **Learning:** Using Tailwind's `hidden` class on `<input type="file">` removes it from the accessibility tree and keyboard tab order, breaking keyboard navigation for custom file uploads.
 **Action:** Always use `sr-only` instead of `hidden` for file inputs, and apply `focus-within:ring-2 focus-within:outline-none` to their wrapping `<label>` to provide a visual focus indicator for keyboard users.
+
+## 2025-02-23 - Window Controls Accessibility
+
+**Learning:** Accessibility attributes (like ARIA labels and focus styles) are often implemented individually on repeated UI patterns, such as window controls (minimize/maximize/close buttons), rather than being abstracted. This leads to inconsistencies and missing a11y support on newly created or updated windows.
+**Action:** Always audit all instances across the codebase (e.g., all files in `app/components/windows/`) when fixing accessibility issues on repeated UI patterns to ensure consistent application of ARIA labels, titles, and focus styles.

--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -48,8 +48,10 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
               onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -38,22 +38,34 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
             <IconBrandSpotify size={20} className="text-[#1DB954]" />
             <span className="text-white/90 text-sm font-medium">Spotify Stats</span>
           </div>
-          <div className="flex items-center gap-4">
-            <button
+          <div className="flex items-center gap-1">
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
-              <IconMinus size={18} />
-            </button>
-            <button
+              <IconMinus size={14} className="text-white/80" />
+            </motion.button>
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
-              <IconSquare size={16} />
-            </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
-              <IconX size={20} />
-            </button>
+              <IconSquare size={14} className="text-white/80" />
+            </motion.button>
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
+            >
+              <IconX size={14} className="text-white/80" />
+            </motion.button>
           </div>
         </motion.div>
 


### PR DESCRIPTION
- 💡 What: Added ARIA labels, titles, and focus-visible styles to the window controls in GamesWindow and SpotifyWindow.
- 🎯 Why: To ensure consistent screen reader support and keyboard navigation for all window components across the application.
- 📸 Before/After: Visuals of the focus styles being added.
- ♿ Accessibility: Improved screen reader announcements and keyboard focus indication for the affected interactive elements.

---
*PR created automatically by Jules for task [18094112627582963416](https://jules.google.com/task/18094112627582963416) started by @Pranav322*