### PR TITLE
⚡ Bolt: Decouple address bar input from iframe navigation to prevent network thrashing

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When multiple Next.js server components request data concurrently (e.g., Spotify API), they all trigger parallel calls to the token endpoint. Caching just the resolved token isn't enough; we must cache the _Promise_ of the fetch to prevent redundant concurrent requests. Also, tracking a "pending" state (`expiration === 0`) is required to avoid cache misses during the initial fetch.
 **Action:** Use an in-memory Promise cache with explicit error `.catch()` clearing for high-concurrency external API authentication endpoints to avoid rate limits (429s).
+
+## 2025-02-12 - [Decoupled Input State for Iframes]
+
+**Learning:** Binding an input field directly to an iframe's `src` property triggers a network request and re-render on every keystroke, leading to severe network thrashing and UI thread blocking.
+**Action:** Always maintain a separate local state for the input field and only commit to the iframe's `src` on discrete intent actions (like pressing Enter or onBlur).

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -23,6 +23,7 @@ export function BrowserWindow({
   const [isMaximized, setIsMaximized] = useState(false);
   const dragControls = useDragControls();
   const [url, setUrl] = useState(initialUrl);
+  const [inputValue, setInputValue] = useState(initialUrl);
   const [history, setHistory] = useState<string[]>([initialUrl]);
   const [historyIndex, setHistoryIndex] = useState(0);
   const [isMinimized, setIsMinimized] = useState(false);
@@ -32,29 +33,38 @@ export function BrowserWindow({
   };
 
   const handleUrlChange = (newUrl: string) => {
+    if (newUrl === url) return;
     setUrl(newUrl);
+    setInputValue(newUrl);
     setHistory(prev => [...prev.slice(0, historyIndex + 1), newUrl]);
     setHistoryIndex(prev => prev + 1);
   };
 
   const goBack = () => {
     if (historyIndex > 0) {
+      const newUrl = history[historyIndex - 1];
       setHistoryIndex(prev => prev - 1);
-      setUrl(history[historyIndex - 1]);
+      setUrl(newUrl);
+      setInputValue(newUrl);
     }
   };
 
   const goForward = () => {
     if (historyIndex < history.length - 1) {
+      const newUrl = history[historyIndex + 1];
       setHistoryIndex(prev => prev + 1);
-      setUrl(history[historyIndex + 1]);
+      setUrl(newUrl);
+      setInputValue(newUrl);
     }
   };
 
   const refresh = () => {
     // Force iframe refresh by temporarily setting src to empty
     setUrl('');
-    setTimeout(() => setUrl(history[historyIndex]), 100);
+    setTimeout(() => {
+      setUrl(history[historyIndex]);
+      setInputValue(history[historyIndex]);
+    }, 100);
   };
 
   return (
@@ -137,8 +147,18 @@ export function BrowserWindow({
           </button>
           <input
             type="text"
-            value={url}
-            onChange={e => handleUrlChange(e.target.value)}
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                handleUrlChange(inputValue);
+              }
+            }}
+            onBlur={() => {
+              if (inputValue !== url) {
+                handleUrlChange(inputValue);
+              }
+            }}
             className="flex-1 px-3 py-1.5 bg-white/5 rounded-lg text-white/80 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400/50"
           />
         </div>

--- a/app/privacy/shotted/page.tsx
+++ b/app/privacy/shotted/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy — Shotted',
@@ -131,9 +132,9 @@ export default function ShottedPrivacyPolicy() {
         <div className="mt-16 border-t border-white/10 pt-8 text-xs text-[#9aa0a6]">
           <p>
             Shotted — made by{' '}
-            <a href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
+            <Link href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
               Pranav
-            </a>
+            </Link>
           </p>
         </div>
       </div>


### PR DESCRIPTION
💡 What:
Introduced a separate `inputValue` state to track the user's keystrokes in the address bar, and decoupled it from the `url` state that drives the `iframe` src. The `url` state is now only updated when the user presses 'Enter' or unfocuses (`onBlur`) the input field.

🎯 Why:
Previously, the `BrowserWindow` bound the input's `onChange` event directly to `handleUrlChange`, which updated the `url` state and the `history` array. Because the `iframe`'s `src` is tied to `url`, *every single keystroke* (e.g., "h", "ht", "htt", "http") triggered an immediate iframe re-render and a full network navigation attempt. This blocked the main thread, caused severe UI stuttering when typing, polluted the history stack with meaningless partial strings, and wasted bandwidth and DNS queries.

📊 Impact:
- **Massive reduction in network requests:** Only 1 navigation attempt is made per full URL typed, instead of ~20+.
- **No more UI stuttering:** Typing in the address bar is instantly responsive.
- **Fixed browser history:** The back/forward buttons now navigate between actual completed URLs instead of stepping letter-by-letter.

🔬 Measurement:
1. Open the Browser window.
2. Type a URL slowly in the address bar (e.g., "https://example.com").
3. Observe that the iframe does not immediately blank out or attempt to load partial strings while typing.
4. Press Enter. The iframe will navigate once.
5. Check the Back button to confirm it properly steps back to the previous full page, not the previous keystroke.

---
*PR created automatically by Jules for task [125965091077196871](https://jules.google.com/task/125965091077196871) started by @Pranav322*