### PR TITLE
🎨 Palette: Accessible Window Controls and Consistent Hover States

### DIFF
--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -48,7 +48,9 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
               onClick={handleMinimize}
             >
               <IconMinus size={14} className="text-white/80" />

--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -38,22 +38,34 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
             <IconBrandSpotify size={20} className="text-[#1DB954]" />
             <span className="text-white/90 text-sm font-medium">Spotify Stats</span>
           </div>
-          <div className="flex items-center gap-4">
-            <button
+          <div className="flex items-center gap-1">
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
-              <IconMinus size={18} />
-            </button>
-            <button
+              <IconMinus size={14} className="text-white/80" />
+            </motion.button>
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
-              <IconSquare size={16} />
-            </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
-              <IconX size={20} />
-            </button>
+              <IconSquare size={14} className="text-white/80" />
+            </motion.button>
+            <motion.button
+              whileHover={{ backgroundColor: 'rgba(239, 68, 68, 0.2)' }}
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
+            >
+              <IconX size={14} className="text-white/80" />
+            </motion.button>
           </div>
         </motion.div>
 

--- a/app/privacy/shotted/page.tsx
+++ b/app/privacy/shotted/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy — Shotted',
@@ -131,9 +132,9 @@ export default function ShottedPrivacyPolicy() {
         <div className="mt-16 border-t border-white/10 pt-8 text-xs text-[#9aa0a6]">
           <p>
             Shotted — made by{' '}
-            <a href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
+            <Link href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
               Pranav
-            </a>
+            </Link>
           </p>
         </div>
       </div>


### PR DESCRIPTION
💡 What:
Added missing `aria-label`, `title`, and keyboard focus styles (`focus-visible`) to the control buttons (Minimize, Maximize, Close) in `GamesWindow.tsx` and `SpotifyWindow.tsx`. In `SpotifyWindow.tsx`, standard HTML `<button>` elements were updated to use `motion.button` components to match the interaction design (hover states) of other windows in the application. Also resolved a minor Next.js routing lint error by replacing an `<a>` tag with Next's `<Link>` component.

🎯 Why:
Users who navigate via keyboard were previously unable to tell when window control buttons in `SpotifyWindow` and the minimize button in `GamesWindow` were focused, as they lacked focus indicators. Furthermore, screen reader users lacked context for these icon-only buttons due to missing `aria-label` attributes. Sighted mouse users were missing tooltip context on hover. Consolidating around `motion.button` ensures a unified, predictable UI experience across all draggable windows.

📸 Before/After:
*Before:* The minimize button on `GamesWindow` and all controls on `SpotifyWindow` were inaccessible to keyboard and screen-reader users and lacked tooltips.
*After:* All control buttons now consistently announce their purpose to screen readers, provide visual tooltips on hover/focus, show clear focus rings when tabbed to, and feature smooth `framer-motion` hover states.

♿ Accessibility:
- Added `aria-label` and `title` attributes to provide context for icon-only buttons.
- Added `focus-visible:ring-2` to provide clear visual feedback during keyboard navigation.

---
*PR created automatically by Jules for task [345575364464630523](https://jules.google.com/task/345575364464630523) started by @Pranav322*