### PR TITLE
⚡ Bolt: [deduplicate concurrent spotify api calls]

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When multiple Next.js server components request data concurrently (e.g., Spotify API), they all trigger parallel calls to the token endpoint. Caching just the resolved token isn't enough; we must cache the _Promise_ of the fetch to prevent redundant concurrent requests. Also, tracking a "pending" state (`expiration === 0`) is required to avoid cache misses during the initial fetch.
 **Action:** Use an in-memory Promise cache with explicit error `.catch()` clearing for high-concurrency external API authentication endpoints to avoid rate limits (429s).
+
+## 2025-02-12 - [Client-Side Deduplication of Sibling API Requests]
+
+**Learning:** Client-side sibling components (like TopArtists and TopGenres) fetching the same endpoint simultaneously on mount trigger redundant duplicate network requests.
+**Action:** Implement an in-memory client-side Promise cache (e.g., `deduplicatedFetchJSON`) to deduplicate concurrent fetch requests across frontend components.

--- a/app/components/spotify/NowPlaying.tsx
+++ b/app/components/spotify/NowPlaying.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IconMusic, IconPlayerPlay, IconPlayerPause } from '@tabler/icons-react';
+import { deduplicatedFetchJSON } from '../../../lib/fetch';
 
 interface NowPlayingResponse {
   isPlaying: boolean;
@@ -17,8 +18,7 @@ export function NowPlaying() {
   useEffect(() => {
     const fetchNowPlaying = async () => {
       try {
-        const res = await fetch('/api/spotify/now-playing');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/now-playing');
         setData(data);
       } catch (error) {
         console.error('Error fetching now playing:', error);

--- a/app/components/spotify/Playlists.tsx
+++ b/app/components/spotify/Playlists.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { IconPlaylist } from '@tabler/icons-react';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { deduplicatedFetchJSON } from '../../../lib/fetch';
 interface Playlist {
   name: string;
   image: string;
@@ -15,8 +16,7 @@ export function Playlists() {
   useEffect(() => {
     const fetchPlaylists = async () => {
       try {
-        const res = await fetch('/api/spotify/playlists');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/playlists');
         setPlaylists(data.playlists);
       } finally {
         setLoading(false);

--- a/app/components/spotify/RecentlyPlayed.tsx
+++ b/app/components/spotify/RecentlyPlayed.tsx
@@ -2,6 +2,7 @@ import { IconClock } from '@tabler/icons-react';
 import { useState, useEffect } from 'react';
 import { Track } from '@/types/spotify';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { deduplicatedFetchJSON } from '../../../lib/fetch';
 
 export function RecentlyPlayed() {
   const [tracks, setTracks] = useState<Track[]>([]);
@@ -10,8 +11,7 @@ export function RecentlyPlayed() {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await fetch('/api/spotify/recently-played');
-        const { tracks } = await res.json();
+        const { tracks } = await deduplicatedFetchJSON('/api/spotify/recently-played');
         setTracks(tracks);
       } catch (error) {
         console.error('Error fetching recently played:', error);

--- a/app/components/spotify/TopArtists.tsx
+++ b/app/components/spotify/TopArtists.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LoadingSpinner } from '../ui/LoadingSpinner';
+import { deduplicatedFetchJSON } from '../../../lib/fetch';
 
 interface Artist {
   name: string;
@@ -15,8 +16,7 @@ export function TopArtists() {
   useEffect(() => {
     const fetchTopArtists = async () => {
       try {
-        const res = await fetch('/api/spotify/top-artists');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/top-artists');
         setArtists(data.artists);
       } finally {
         setLoading(false);

--- a/app/components/spotify/TopGenres.tsx
+++ b/app/components/spotify/TopGenres.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { deduplicatedFetchJSON } from '../../../lib/fetch';
 
 export function TopGenres() {
   const [genres, setGenres] = useState<{ genre: string; count: number }[]>([]);
 
   useEffect(() => {
     const fetchGenres = async () => {
-      const res = await fetch('/api/spotify/top-artists');
-      const data = await res.json();
+      const data = await deduplicatedFetchJSON('/api/spotify/top-artists');
       const genreCount = data.artists.reduce((acc: any, artist: any) => {
         artist.genres.forEach((genre: string) => {
           acc[genre] = (acc[genre] || 0) + 1;

--- a/app/components/spotify/TopTracks.tsx
+++ b/app/components/spotify/TopTracks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IconMusic } from '@tabler/icons-react';
+import { deduplicatedFetchJSON } from '../../../lib/fetch';
 
 interface Track {
   title: string;
@@ -15,8 +16,7 @@ export function TopTracks() {
   useEffect(() => {
     const fetchTopTracks = async () => {
       try {
-        const res = await fetch('/api/spotify/top-tracks');
-        const data = await res.json();
+        const data = await deduplicatedFetchJSON('/api/spotify/top-tracks');
         setTracks(data.tracks);
       } catch (error) {
         console.error('Error fetching top tracks:', error);

--- a/app/privacy/shotted/page.tsx
+++ b/app/privacy/shotted/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy — Shotted',
@@ -131,9 +132,9 @@ export default function ShottedPrivacyPolicy() {
         <div className="mt-16 border-t border-white/10 pt-8 text-xs text-[#9aa0a6]">
           <p>
             Shotted — made by{' '}
-            <a href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
+            <Link href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
               Pranav
-            </a>
+            </Link>
           </p>
         </div>
       </div>

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,0 +1,31 @@
+const fetchCache = new Map<string, Promise<any>>();
+
+export function deduplicatedFetchJSON<T = any>(url: string, options?: RequestInit): Promise<T> {
+  if (options?.method && options.method.toUpperCase() !== 'GET') {
+    return fetch(url, options).then(res => {
+      if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+      return res.json();
+    });
+  }
+
+  const cacheKey = url;
+  if (fetchCache.has(cacheKey)) {
+    return fetchCache.get(cacheKey)!;
+  }
+
+  const promise = fetch(url, options)
+    .then(res => {
+      if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+      return res.json();
+    })
+    .catch(err => {
+      fetchCache.delete(cacheKey);
+      throw err;
+    })
+    .finally(() => {
+      setTimeout(() => fetchCache.delete(cacheKey), 50);
+    });
+
+  fetchCache.set(cacheKey, promise);
+  return promise;
+}


### PR DESCRIPTION
💡 What: Replaced raw fetch calls in client-side Spotify components with a deduplicatedFetchJSON utility using an in-memory Promise cache. Also changed a native anchor tag to a Next.js Link on the privacy page to resolve a linting error.

🎯 Why: Sibling components like TopArtists and TopGenres fetch the same `/api/spotify/top-artists` endpoint on mount, causing duplicate redundant network requests. 

📊 Impact: Reduces initial API requests by 50% for duplicated endpoints when SpotifyWindow mounts, saving bandwidth and rate limits.

🔬 Measurement: Observe the Network tab; only a single request to `/api/spotify/top-artists` will be fired instead of two.

---
*PR created automatically by Jules for task [14465903332116811432](https://jules.google.com/task/14465903332116811432) started by @Pranav322*