### PR TITLE
🎨 Palette: Add aria-label and title to GamesWindow minimize button

### DIFF
--- a/app/components/windows/GamesWindow.tsx
+++ b/app/components/windows/GamesWindow.tsx
@@ -48,8 +48,10 @@ export function GamesWindow({ onClose }: GamesWindowProps) {
           <div className="flex items-center gap-1">
             <motion.button
               whileHover={{ backgroundColor: 'rgba(107, 114, 128, 0.2)' }}
-              className="p-2 rounded-full"
               onClick={handleMinimize}
+              aria-label="Minimize"
+              title="Minimize"
+              className="p-2 rounded-full focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-white/50"
             >
               <IconMinus size={14} className="text-white/80" />
             </motion.button>


### PR DESCRIPTION
💡 What: Added `aria-label="Minimize"`, `title="Minimize"`, and `focus-visible` Tailwind utility classes to the minimize `<motion.button>` within the `GamesWindow` component.

🎯 Why: To maintain consistency with all other window components across the application, which already possess these attributes on their minimize buttons. This ensures a uniform user experience for keyboard and screen reader users navigating the desktop environment.

📸 Before/After: Visual changes are restricted to keyboard focus states (a white ring is now displayed when focused via Tab). Hover tooltips also now correctly display "Minimize" instead of nothing.

♿ Accessibility:
- Improves screen reader support by announcing the button's purpose instead of relying on the raw icon.
- Provides a native hover tooltip (`title`) for context to mouse users.
- Adds explicit focus-visible styles for keyboard users, making it clear when the minimize button is focused.

---
*PR created automatically by Jules for task [14983214315448568288](https://jules.google.com/task/14983214315448568288) started by @Pranav322*