### PR TITLE
⚡ Bolt: [performance improvement] Prevent iframe network thrashing on keystrokes

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -7,3 +7,8 @@
 
 **Learning:** When multiple Next.js server components request data concurrently (e.g., Spotify API), they all trigger parallel calls to the token endpoint. Caching just the resolved token isn't enough; we must cache the _Promise_ of the fetch to prevent redundant concurrent requests. Also, tracking a "pending" state (`expiration === 0`) is required to avoid cache misses during the initial fetch.
 **Action:** Use an in-memory Promise cache with explicit error `.catch()` clearing for high-concurrency external API authentication endpoints to avoid rate limits (429s).
+
+## 2025-02-13 - [Iframe SRC Binding and Network Thrashing]
+
+**Learning:** Binding an input field's state directly to an iframe's `src` property triggers an immediate reload and network request on every single keystroke. This causes severe network thrashing, UI thread blocking, and browser history pollution.
+**Action:** Always maintain a separate local state for the input field and only commit the URL to the iframe's `src` on discrete intent actions like `Enter` key press or `onBlur`.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 node_modules
 .next
 build
-dist 
+dist pranav/.venv/**
+pranav/.pytest_cache/**

--- a/app/components/windows/BrowserWindow.tsx
+++ b/app/components/windows/BrowserWindow.tsx
@@ -23,6 +23,7 @@ export function BrowserWindow({
   const [isMaximized, setIsMaximized] = useState(false);
   const dragControls = useDragControls();
   const [url, setUrl] = useState(initialUrl);
+  const [inputValue, setInputValue] = useState(initialUrl);
   const [history, setHistory] = useState<string[]>([initialUrl]);
   const [historyIndex, setHistoryIndex] = useState(0);
   const [isMinimized, setIsMinimized] = useState(false);
@@ -32,15 +33,22 @@ export function BrowserWindow({
   };
 
   const handleUrlChange = (newUrl: string) => {
-    setUrl(newUrl);
-    setHistory(prev => [...prev.slice(0, historyIndex + 1), newUrl]);
-    setHistoryIndex(prev => prev + 1);
+    setInputValue(newUrl);
+  };
+
+  const commitUrl = () => {
+    if (inputValue !== url) {
+      setUrl(inputValue);
+      setHistory(prev => [...prev.slice(0, historyIndex + 1), inputValue]);
+      setHistoryIndex(prev => prev + 1);
+    }
   };
 
   const goBack = () => {
     if (historyIndex > 0) {
       setHistoryIndex(prev => prev - 1);
       setUrl(history[historyIndex - 1]);
+      setInputValue(history[historyIndex - 1]);
     }
   };
 
@@ -48,6 +56,7 @@ export function BrowserWindow({
     if (historyIndex < history.length - 1) {
       setHistoryIndex(prev => prev + 1);
       setUrl(history[historyIndex + 1]);
+      setInputValue(history[historyIndex + 1]);
     }
   };
 
@@ -137,8 +146,14 @@ export function BrowserWindow({
           </button>
           <input
             type="text"
-            value={url}
+            value={inputValue}
             onChange={e => handleUrlChange(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                commitUrl();
+              }
+            }}
+            onBlur={commitUrl}
             className="flex-1 px-3 py-1.5 bg-white/5 rounded-lg text-white/80 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400/50"
           />
         </div>

--- a/app/privacy/shotted/page.tsx
+++ b/app/privacy/shotted/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy — Shotted',
@@ -131,9 +132,9 @@ export default function ShottedPrivacyPolicy() {
         <div className="mt-16 border-t border-white/10 pt-8 text-xs text-[#9aa0a6]">
           <p>
             Shotted — made by{' '}
-            <a href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
+            <Link href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
               Pranav
-            </a>
+            </Link>
           </p>
         </div>
       </div>


### PR DESCRIPTION
💡 What: Implement discrete intent updates for the BrowserWindow iframe URL.
🎯 Why: Binding the iframe `src` to the raw input value triggers a network request and history append on every keystroke, causing severe network thrashing.
📊 Impact: Eliminates redundant network requests during typing and prevents history pollution.
🔬 Measurement: Observe network tab while typing in the BrowserWindow address bar; requests will only fire on Enter/Blur instead of per keystroke.

---
*PR created automatically by Jules for task [15615291252146185479](https://jules.google.com/task/15615291252146185479) started by @Pranav322*