### PR TITLE
🎨 Palette: Add accessible controls to Spotify window

### DIFF
--- a/app/components/windows/SpotifyWindow.tsx
+++ b/app/components/windows/SpotifyWindow.tsx
@@ -41,17 +41,26 @@ export function SpotifyWindow({ onClose }: SpotifyWindowProps) {
           <div className="flex items-center gap-4">
             <button
               onClick={handleMinimize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label="Minimize"
+              title="Minimize"
+              className="text-white/50 hover:text-white transition-colors p-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
               <IconMinus size={18} />
             </button>
             <button
               onClick={toggleMaximize}
-              className="text-white/50 hover:text-white transition-colors"
+              aria-label={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? 'Restore' : 'Maximize'}
+              className="text-white/50 hover:text-white transition-colors p-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
             >
               <IconSquare size={16} />
             </button>
-            <button onClick={onClose} className="text-white/50 hover:text-white transition-colors">
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className="text-white/50 hover:text-white transition-colors p-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50"
+            >
               <IconX size={20} />
             </button>
           </div>

--- a/app/privacy/shotted/page.tsx
+++ b/app/privacy/shotted/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy — Shotted',
@@ -131,9 +132,9 @@ export default function ShottedPrivacyPolicy() {
         <div className="mt-16 border-t border-white/10 pt-8 text-xs text-[#9aa0a6]">
           <p>
             Shotted — made by{' '}
-            <a href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
+            <Link href="/" className="text-[#8ab4f8] hover:text-white transition-colors">
               Pranav
-            </a>
+            </Link>
           </p>
         </div>
       </div>


### PR DESCRIPTION
💡 What: Added `aria-label`, `title`, and keyboard focus styles (`focus-visible:ring-2`) to the minimize, maximize, and close buttons within `SpotifyWindow.tsx`. Additionally, replaced a native `<a>` tag with Next.js's `<Link>` in `app/privacy/shotted/page.tsx` to fix a `next lint` deprecation warning.

🎯 Why: Icon-only buttons without accessible labels fail to provide context to screen reader users. Furthermore, missing focus states make keyboard navigation extremely difficult. This brings the Spotify Window up to the accessibility standards observed in other window components in this project. The `Link` change prevents lint failures.

📸 Before/After: Visuals for keyboard focus rings are now visible on tab navigation. No visual regressions for mouse users. 

♿ Accessibility: Ensures that users navigating via screen readers hear meaningful labels ("Minimize", "Maximize", "Restore", "Close") and keyboard users see a clear visual indicator when focused on window control actions.

---
*PR created automatically by Jules for task [16952116229098639284](https://jules.google.com/task/16952116229098639284) started by @Pranav322*